### PR TITLE
Axum 0.8

### DIFF
--- a/packages/axum-helmet/Cargo.toml
+++ b/packages/axum-helmet/Cargo.toml
@@ -14,14 +14,14 @@ categories = ["web-programming", "http", "middleware"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.7"
+axum = "0.8"
 helmet-core = { path = "../helmet-core", version = "0.1.0" }
-tower = "0.4"
+tower = "0.5"
 tower-service = "0.3"
 http = "1.0"
 pin-project-lite = "0.2"
 tokio = "1.35"
 
 [dev-dependencies]
-axum-test = "14.2"
+axum-test = "17.2"
 tokio = { version = "1.35", features = ["rt-multi-thread"] }

--- a/packages/helmet-core/src/lib.rs
+++ b/packages/helmet-core/src/lib.rs
@@ -1391,7 +1391,7 @@ impl<'a> ContentSecurityPolicy<'a> {
     }
 }
 
-impl<'a> Display for ContentSecurityPolicy<'a> {
+impl Display for ContentSecurityPolicy<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let directives = self
             .directives
@@ -1403,7 +1403,7 @@ impl<'a> Display for ContentSecurityPolicy<'a> {
     }
 }
 
-impl<'a> Default for ContentSecurityPolicy<'a> {
+impl Default for ContentSecurityPolicy<'_> {
     /// Default policy for the Content-Security-Policy header.
     ///
     /// values:
@@ -1436,7 +1436,7 @@ impl<'a> Default for ContentSecurityPolicy<'a> {
     }
 }
 
-impl<'a> Header for ContentSecurityPolicy<'a> {
+impl Header for ContentSecurityPolicy<'_> {
     fn name(&self) -> &'static str {
         if self.report_only {
             "Content-Security-Policy-Report-Only"
@@ -1472,6 +1472,7 @@ pub struct Helmet {
     pub headers: Vec<Box<dyn Header>>,
 }
 
+#[allow(clippy::should_implement_trait)]
 impl Helmet {
     /// Create new `Helmet` instance without any headers applied
     pub fn new() -> Self {

--- a/packages/ntex-helmet/src/lib.rs
+++ b/packages/ntex-helmet/src/lib.rs
@@ -102,8 +102,11 @@ where
 {
     type Response = WebResponse;
     type Error = S::Error;
-    type Future<'f> =
-        BoxFuture<'f, Result<Self::Response, Self::Error>> where S: 'f, E: 'f;
+    type Future<'f>
+        = BoxFuture<'f, Result<Self::Response, Self::Error>>
+    where
+        S: 'f,
+        E: 'f;
 
     forward_poll_ready!(service);
     forward_poll_shutdown!(service);
@@ -126,8 +129,10 @@ where
 /// ```rust
 /// use ntex::web;
 /// use ntex_helmet::Helmet;
+#[derive(Default)]
 pub struct Helmet(HelmetCore);
 
+#[allow(clippy::should_implement_trait)]
 impl Helmet {
     pub fn new() -> Self {
         Self(HelmetCore::new())
@@ -135,12 +140,6 @@ impl Helmet {
 
     pub fn add(self, middleware: impl helmet_core::Header + 'static) -> Self {
         Self(self.0.add(middleware))
-    }
-}
-
-impl Default for Helmet {
-    fn default() -> Self {
-        Self(HelmetCore::default())
     }
 }
 


### PR DESCRIPTION
Hi! Thanks for the awesome suite of crates :)

If you consider this appropriate, please take a look at this PR. There are two things:

## Updated axum to v0.8
One-liner, 98e03b4033980e08582ecdcae87e1593214be868

## Fixed clippy warnings
I fixed the warnings about lifetimes and Default implementation, but for the warning about the Add trait implementation, I just added an `allow` attribute.

Here's the warning text:
```
warning: method `add` can be confused for the standard trait method `std::ops::Add::add`
   --> packages/ntex-helmet/src/lib.rs:140:5
    |
140 | /     pub fn add(self, middleware: impl helmet_core::Header + 'static) -> Self {
141 | |         Self(self.0.add(middleware))
142 | |     }
    | |_____^
    |
    = help: consider implementing the trait `std::ops::Add` or choosing a less ambiguous method name
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait
    = note: `#[warn(clippy::should_implement_trait)]` on by default
```

I thought it would be up to you to decide whether you want to make such a change or not. Let me know if you'd like me to change it.