### PR TITLE
feat: simplify core + add actix web + update ntex

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -32,7 +32,6 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          all-features: true
           args: --verbose
   publish:
     name: Publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,6 @@ members = [
   "packages/ntex-helmet",
   "packages/helmet-core",
   "packages/axum-helmet",
+  "packages/actix-web-helmet",
 ]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A security middleware library for popular Rust web frameworks.
 ## Packages
 
 - `ntex-helmet` is a security middleware for the `ntex` web framework.
-- `actix-web-helmet` is a security middleware for the `actix-web` web framework. **_Coming Soon_**
+- `actix-web-helmet` is a security middleware for the `actix-web` web framework.
 - `rocket-helmet` is a security middleware for the `rocket` web framework. **_Coming Soon_**
 - `warp-helmet` is a security middleware for the `warp` web framework. **_Coming Soon_**
 - `axum-helmet` is a security middleware for the `axum` web framework.

--- a/packages/actix-web-helmet/Cargo.toml
+++ b/packages/actix-web-helmet/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
-name = "ntex-helmet"
-version = "0.1.3"
+name = "actix-web-helmet"
+version = "0.1.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
-description = "HTTP security headers middleware for ntex-web"
+description = "HTTP security headers middleware for actix-web"
 readme = "README.md"
 license = "MIT"
 homepage = "https://github.com/danielkov/rust-helmet"
 repository = "https://github.com/danielkov/rust-helmet"
-keywords = ["ntex", "ntex-web", "helmet", "security", "middleware"]
+keywords = ["actix", "actix-web", "helmet", "security", "middleware"]
 categories = ["web-programming", "http", "middleware"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ntex = { version = "2.12", features = ["tokio"] }
+actix-web = { version = "4.10" }
 helmet-core = { path = "../helmet-core", version = "0.1.0" }
+futures = { version = "0.3" }
 
 [dev-dependencies]
-ntex = { version = "2.12", features = ["tokio"] }
+actix-web = { version = "4.10" }

--- a/packages/actix-web-helmet/Cargo.toml
+++ b/packages/actix-web-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-helmet"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for actix-web"
@@ -15,7 +15,7 @@ categories = ["web-programming", "http", "middleware"]
 
 [dependencies]
 actix-web = { version = "4.10" }
-helmet-core = { path = "../helmet-core", version = "0.1.0" }
+helmet-core = { path = "../helmet-core", version = "0.2.0" }
 futures = { version = "0.3" }
 
 [dev-dependencies]

--- a/packages/actix-web-helmet/README.md
+++ b/packages/actix-web-helmet/README.md
@@ -1,0 +1,52 @@
+# `actix-web-helmet` - Security Middleware for `ntex` web framework
+
+[![crate](https://img.shields.io/crates/v/actix-web-helmet.svg)](https://crates.io/crates/actix-web-helmet)
+[![docs](https://docs.rs/actix-web-helmet/badge.svg)](https://docs.rs/actix-web-helmet)
+
+`actix-web-helmet` is a security middleware for the `actix-web` web framework. It's based on the [helmet](https://helmetjs.github.io/) middleware for Node.js.
+
+It works by setting HTTP headers for you. These headers can help protect your app from some well-known web vulnerabilities:
+
+- [Cross-Origin-Embedder-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy)
+- [Cross-Origin-Opener-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)
+- [Cross-Origin-Resource-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy)
+- [Origin-Agent-Cluster](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin-Agent-Cluster)
+- [Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
+- [Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
+- [X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)
+- [X-DNS-Prefetch-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control)
+- [X-Download-Options](<https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/ms537628(v=vs.85)?redirectedfrom=MSDN>)
+- [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options)
+- [X-Permitted-Cross-Domain-Policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Permitted-Cross-Domain-Policies)
+- [X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)
+- [X-Powered-By](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Powered-By)
+- [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+actix-web-helmet = "0.1"
+```
+
+## Example
+
+```rust
+use actix_web::{web, App, HttpResponse};
+use actix_web_helmet::Helmet;
+
+#[actix_web::main]
+async fn main() {
+    let app = App::new()
+        .wrap(Helmet::default())
+        .service(web::resource("/").to(|| HttpResponse::Ok()));
+
+    // ...
+}
+```
+
+## License
+
+This project is licensed under the [MIT license](LICENSE).

--- a/packages/actix-web-helmet/src/lib.rs
+++ b/packages/actix-web-helmet/src/lib.rs
@@ -1,0 +1,265 @@
+//! `actix-web-helmet` is a middleware for securing your Actix-Web application with various HTTP headers.
+//!
+//! `actix_web_helmet::Helmet` is a middleware that can be used to set various HTTP headers that can help protect your app from well-known web vulnerabilities.
+//!
+//! It is based on the [Helmet](https://helmetjs.github.io/) middleware for Express.js.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use actix_web::{web, App, HttpServer, Responder, get};
+//! use actix_web_helmet::Helmet;
+//!
+//! #[get("/")]
+//! async fn index() -> impl Responder {
+//!   "Hello, World!"
+//! }
+//!
+//! #[actix_web::main]
+//! async fn main() -> std::io::Result<()> {
+//!  HttpServer::new(|| App::new().wrap(Helmet::default()).service(index))
+//!      .bind(("127.0.0.1", 8080))?
+//!      .run()
+//!      .await
+//! }
+//! ```
+//!
+//! By default Helmet will set the following headers:
+//!
+//! ```text
+//! Content-Security-Policy: default-src 'self'; base-uri 'self'; font-src 'self' https: data:; form-action 'self'; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' https: 'unsafe-inline'; upgrade-insecure-requests
+//! Cross-Origin-Opener-Policy: same-origin
+//! Cross-Origin-Resource-Policy: same-origin
+//! Origin-Agent-Cluster: ?1
+//! Referrer-Policy: no-referrer
+//! Strict-Transport-Security: max-age=15552000; includeSubDomains
+//! X-Content-Type-Options: nosniff
+//! X-DNS-Prefetch-Control: off
+//! X-Download-Options: noopen
+//! X-Frame-Options: sameorigin
+//! X-Permitted-Cross-Domain-Policies: none
+//! X-XSS-Protection: 0
+//! ```
+//!
+//! This might be a good starting point for most users, but it is highly recommended to spend some time with the documentation for each header, and adjust them to your needs.
+//!
+//! # Configuration
+//!
+//! By default if you construct a new instance of `Helmet` it will not set any headers.
+//!
+//! It is possible to configure `Helmet` to set only the headers you want, by using the `add` method to add headers.
+//!
+//! ```no_run
+//! use actix_web::{get, web, App, HttpServer, Responder};
+//! use actix_web_helmet::{Helmet, ContentSecurityPolicy, CrossOriginOpenerPolicy};
+//!
+//! #[get("/")]
+//! async fn index() -> impl Responder {
+//!     "Hello, World!"
+//! }
+//!
+//! #[actix_web::main]
+//! async fn main() -> std::io::Result<()> {
+//!     HttpServer::new(|| {
+//!         {
+//!             App::new().wrap(
+//!                 Helmet::new()
+//!                     .add(
+//!                         ContentSecurityPolicy::new()
+//!                             .child_src(vec!["'self'"])
+//!                             .child_src(vec!["'self'", "https://youtube.com"])
+//!                             .connect_src(vec!["'self'", "https://youtube.com"])
+//!                             .default_src(vec!["'self'", "https://youtube.com"])
+//!                             .font_src(vec!["'self'", "https://youtube.com"]),
+//!                     )
+//!                     .add(CrossOriginOpenerPolicy::same_origin_allow_popups()),
+//!             )
+//!         }
+//!         .service(index)
+//!     })
+//!     .bind(("127.0.0.1", 8080))?
+//!     .run()
+//!     .await
+//! }
+//! ```
+use std::future::Future;
+use std::pin::Pin;
+
+use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform};
+use actix_web::http::header::{HeaderName, HeaderValue};
+use actix_web::Error;
+use futures::future::{ok, Ready};
+
+use helmet_core::Helmet as HelmetCore;
+
+// re-export helmet_core::*, except for the `Helmet` struct
+pub use helmet_core::*;
+
+pub struct HelmetMiddleware<S> {
+    inner: HelmetCore,
+    service: S,
+}
+
+/// Helmet middleware
+/// ```rust
+/// use actix_web::{web, App, HttpServer};
+/// use actix_web_helmet::Helmet;
+/// ```
+pub struct Helmet(HelmetCore);
+
+impl Helmet {
+    /// Create a new instance of `Helmet` with no headers set.
+    pub fn new() -> Self {
+        Self(HelmetCore::new())
+    }
+
+    /// Add a header to the middleware.
+    pub fn add(self, middleware: impl Into<helmet_core::Header>) -> Self {
+        Self(self.0.add(middleware))
+    }
+}
+
+impl<S, B> Transform<S, ServiceRequest> for Helmet
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static, // Add 'static bound
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type InitError = ();
+    // The actual middleware service that will be created
+    type Transform = HelmetMiddleware<S>;
+    // The future that resolves to the middleware service
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        // Create the middleware service instance HelmetMiddleware
+        // Clone the inner configuration (HelmetCore).
+        // HelmetCore should derive Clone or you might need to wrap it in Rc/Arc.
+        // Assuming HelmetCore is Clone:
+        ok(HelmetMiddleware {
+            inner: self.0.clone(), // Clone the configuration from the factory
+            service,               // Pass the next service in the chain
+        })
+
+        // If HelmetCore is large and not Clone, you might wrap it in Rc in the Helmet struct:
+        // pub struct Helmet(Rc<HelmetCore>);
+        // And then clone the Rc here:
+        // ok(HelmetMiddleware {
+        //     inner: self.0.clone(),
+        //     service,
+        // })
+    }
+}
+
+impl Default for Helmet {
+    fn default() -> Self {
+        Self(HelmetCore::default())
+    }
+}
+
+type LocalBoxFuture<T> = Pin<Box<dyn Future<Output = T> + 'static>>;
+
+impl<S, B> Service<ServiceRequest> for HelmetMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<Result<Self::Response, Self::Error>>;
+
+    // This service is ready when its next service is ready
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let fut = self.service.call(req);
+
+        let headers_vec = self
+            .inner
+            .headers
+            .iter()
+            .map(|header| (header.0, header.1.clone()))
+            .collect::<Vec<_>>();
+
+        Box::pin(async move {
+            let mut res = fut.await?;
+
+            // Set the headers
+            for (name, value) in &headers_vec {
+                res.headers_mut().insert(
+                    HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                    HeaderValue::from_str(value).unwrap(),
+                );
+            }
+            Ok(res)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::http::header::{HeaderName, HeaderValue};
+    // Make sure HttpResponse is imported if not already
+    use actix_web::{http, test, web, App, HttpResponse}; // Added test, http, HttpResponse
+
+    use super::*; // Keep this
+
+    #[actix_web::test]
+    async fn test_helmet() {
+        // 1. Create the middleware *factory* instance
+        let helmet_factory =
+            Helmet::new().add(ContentSecurityPolicy::new().child_src(vec!["'self'"]));
+
+        // 2. Initialize the service using the factory with .wrap()
+        let app = test::init_service(
+            // Use test::init_service
+            App::new()
+                .wrap(helmet_factory) // Use the factory here
+                // Define a simple async route correctly
+                .route("/", web::get().to(|| async { HttpResponse::Ok().finish() })),
+        )
+        .await;
+
+        // 3. Create a request
+        let req = test::TestRequest::get().uri("/").to_request(); // Use test::TestRequest
+
+        // 4. Call the service
+        let res = test::call_service(&app, req).await; // Use test::call_service and the app
+
+        // 5. Assertions
+        assert!(res.status().is_success()); // Check status code idiomatically
+        assert_eq!(
+            res.headers()
+                .get(HeaderName::from_static("content-security-policy")),
+            Some(&HeaderValue::from_static("child-src 'self'"))
+        );
+    }
+
+    // Optional: Add a test for the default configuration
+    #[actix_web::test]
+    async fn test_helmet_default() {
+        let app = test::init_service(
+            App::new()
+                .wrap(Helmet::default()) // Use the default factory
+                .route("/", web::get().to(|| async { HttpResponse::Ok().finish() })),
+        )
+        .await;
+
+        let req = test::TestRequest::get().uri("/").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert!(resp.status().is_success());
+        // Check one or two default headers to confirm it works
+        assert_eq!(
+            resp.headers().get(http::header::X_FRAME_OPTIONS), // Use constants from http::header
+            Some(&HeaderValue::from_static("SAMEORIGIN"))
+        );
+        assert_eq!(
+            resp.headers().get(http::header::X_XSS_PROTECTION),
+            Some(&HeaderValue::from_static("0"))
+        );
+    }
+}

--- a/packages/axum-helmet/Cargo.toml
+++ b/packages/axum-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-helmet"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware core for axum web framework"
@@ -15,7 +15,7 @@ categories = ["web-programming", "http", "middleware"]
 
 [dependencies]
 axum = "0.8"
-helmet-core = { path = "../helmet-core", version = "0.1.0" }
+helmet-core = { path = "../helmet-core", version = "0.2.0" }
 tower = "0.5"
 tower-service = "0.3"
 http = "1.0"

--- a/packages/axum-helmet/src/lib.rs
+++ b/packages/axum-helmet/src/lib.rs
@@ -73,8 +73,8 @@ impl HelmetLayer {
             .iter()
             .map(|header| {
                 (
-                    HeaderName::try_from(header.name()).expect("invalid header name"),
-                    HeaderValue::try_from(header.value()).expect("invalid header value"),
+                    HeaderName::try_from(header.0).expect("invalid header name"),
+                    HeaderValue::try_from(&header.1).expect("invalid header value"),
                 )
             })
             .collect();

--- a/packages/helmet-core/Cargo.toml
+++ b/packages/helmet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helmet-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware core for various web frameworks"

--- a/packages/helmet-core/src/lib.rs
+++ b/packages/helmet-core/src/lib.rs
@@ -59,20 +59,14 @@ use core::fmt::Display;
 ///
 /// struct MyHeader;
 ///
-/// impl Header for MyHeader {
-///    fn name(&self) -> &'static str {
-///       "My-Header"
-///   }
-///
-///   fn value(&self) -> String {
-///      "my-value".to_string()
-///  }
+/// impl Into<Header> for MyHeader {
+///     fn into(self) -> Header {
+///         ("My-Header", "My-Value".to_owned())
+///    }
 /// }
 /// ```
-pub trait Header {
-    fn name(&self) -> &'static str;
-    fn value(&self) -> String;
-}
+
+pub type Header = (&'static str, String);
 
 /// Manages `Cross-Origin-Embedder-Policy` header
 ///
@@ -116,23 +110,19 @@ impl CrossOriginEmbedderPolicy {
     }
 }
 
-impl Display for CrossOriginEmbedderPolicy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl CrossOriginEmbedderPolicy {
+    pub fn as_str(&self) -> &'static str {
         match self {
-            CrossOriginEmbedderPolicy::UnsafeNone => write!(f, "unsafe-none"),
-            CrossOriginEmbedderPolicy::RequireCorp => write!(f, "require-corp"),
-            CrossOriginEmbedderPolicy::Credentialless => write!(f, "credentialless"),
+            CrossOriginEmbedderPolicy::UnsafeNone => "unsafe-none",
+            CrossOriginEmbedderPolicy::RequireCorp => "require-corp",
+            CrossOriginEmbedderPolicy::Credentialless => "credentialless",
         }
     }
 }
 
-impl Header for CrossOriginEmbedderPolicy {
-    fn name(&self) -> &'static str {
-        "Cross-Origin-Embedder-Policy"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for CrossOriginEmbedderPolicy {
+    fn into(self) -> Header {
+        ("Cross-Origin-Embedder-Policy", self.as_str().to_owned())
     }
 }
 
@@ -174,23 +164,19 @@ impl CrossOriginOpenerPolicy {
     }
 }
 
-impl Display for CrossOriginOpenerPolicy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl CrossOriginOpenerPolicy {
+    fn as_str(&self) -> &'static str {
         match self {
-            CrossOriginOpenerPolicy::SameOrigin => write!(f, "same-origin"),
-            CrossOriginOpenerPolicy::SameOriginAllowPopups => write!(f, "same-origin-allow-popups"),
-            CrossOriginOpenerPolicy::UnsafeNone => write!(f, "unsafe-none"),
+            CrossOriginOpenerPolicy::SameOrigin => "same-origin",
+            CrossOriginOpenerPolicy::SameOriginAllowPopups => "same-origin-allow-popups",
+            CrossOriginOpenerPolicy::UnsafeNone => "unsafe-none",
         }
     }
 }
 
-impl Header for CrossOriginOpenerPolicy {
-    fn name(&self) -> &'static str {
-        "Cross-Origin-Opener-Policy"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for CrossOriginOpenerPolicy {
+    fn into(self) -> Header {
+        ("Cross-Origin-Opener-Policy", self.as_str().to_owned())
     }
 }
 
@@ -232,23 +218,19 @@ impl CrossOriginResourcePolicy {
     }
 }
 
-impl Display for CrossOriginResourcePolicy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl CrossOriginResourcePolicy {
+    fn as_str(&self) -> &'static str {
         match self {
-            CrossOriginResourcePolicy::SameOrigin => write!(f, "same-origin"),
-            CrossOriginResourcePolicy::SameSite => write!(f, "same-site"),
-            CrossOriginResourcePolicy::CrossOrigin => write!(f, "cross-origin"),
+            CrossOriginResourcePolicy::SameOrigin => "same-origin",
+            CrossOriginResourcePolicy::SameSite => "same-site",
+            CrossOriginResourcePolicy::CrossOrigin => "cross-origin",
         }
     }
 }
 
-impl Header for CrossOriginResourcePolicy {
-    fn name(&self) -> &'static str {
-        "Cross-Origin-Resource-Policy"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for CrossOriginResourcePolicy {
+    fn into(self) -> Header {
+        ("Cross-Origin-Resource-Policy", self.as_str().to_owned())
     }
 }
 
@@ -277,23 +259,19 @@ impl OriginAgentCluster {
     }
 }
 
-impl Display for OriginAgentCluster {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl OriginAgentCluster {
+    fn as_str(&self) -> &'static str {
         if self.0 {
-            write!(f, "?1")
+            "?1"
         } else {
-            write!(f, "?0")
+            "?0"
         }
     }
 }
 
-impl Header for OriginAgentCluster {
-    fn name(&self) -> &'static str {
-        "Origin-Agent-Cluster"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for OriginAgentCluster {
+    fn into(self) -> Header {
+        ("Origin-Agent-Cluster", self.as_str().to_owned())
     }
 }
 
@@ -365,30 +343,24 @@ impl ReferrerPolicy {
     }
 }
 
-impl Display for ReferrerPolicy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ReferrerPolicy {
+    fn as_str(&self) -> &'static str {
         match self {
-            ReferrerPolicy::NoReferrer => write!(f, "no-referrer"),
-            ReferrerPolicy::NoReferrerWhenDowngrade => write!(f, "no-referrer-when-downgrade"),
-            ReferrerPolicy::Origin => write!(f, "origin"),
-            ReferrerPolicy::OriginWhenCrossOrigin => write!(f, "origin-when-cross-origin"),
-            ReferrerPolicy::SameOrigin => write!(f, "same-origin"),
-            ReferrerPolicy::StrictOrigin => write!(f, "strict-origin"),
-            ReferrerPolicy::StrictOriginWhenCrossOrigin => {
-                write!(f, "strict-origin-when-cross-origin")
-            }
-            ReferrerPolicy::UnsafeUrl => write!(f, "unsafe-url"),
+            ReferrerPolicy::NoReferrer => "no-referrer",
+            ReferrerPolicy::NoReferrerWhenDowngrade => "no-referrer-when-downgrade",
+            ReferrerPolicy::Origin => "origin",
+            ReferrerPolicy::OriginWhenCrossOrigin => "origin-when-cross-origin",
+            ReferrerPolicy::SameOrigin => "same-origin",
+            ReferrerPolicy::StrictOrigin => "strict-origin",
+            ReferrerPolicy::StrictOriginWhenCrossOrigin => "strict-origin-when-cross-origin",
+            ReferrerPolicy::UnsafeUrl => "unsafe-url",
         }
     }
 }
 
-impl Header for ReferrerPolicy {
-    fn name(&self) -> &'static str {
-        "Referrer-Policy"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for ReferrerPolicy {
+    fn into(self) -> Header {
+        ("Referrer-Policy", self.as_str().to_owned())
     }
 }
 
@@ -465,13 +437,9 @@ impl Display for StrictTransportSecurity {
     }
 }
 
-impl Header for StrictTransportSecurity {
-    fn name(&self) -> &'static str {
-        "Strict-Transport-Security"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for StrictTransportSecurity {
+    fn into(self) -> Header {
+        ("Strict-Transport-Security", self.to_string())
     }
 }
 
@@ -501,6 +469,14 @@ impl XContentTypeOptions {
     }
 }
 
+impl XContentTypeOptions {
+    fn as_str(&self) -> &'static str {
+        match self {
+            XContentTypeOptions::NoSniff => "nosniff",
+        }
+    }
+}
+
 impl Display for XContentTypeOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -509,13 +485,9 @@ impl Display for XContentTypeOptions {
     }
 }
 
-impl Header for XContentTypeOptions {
-    fn name(&self) -> &'static str {
-        "X-Content-Type-Options"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for XContentTypeOptions {
+    fn into(self) -> Header {
+        ("X-Content-Type-Options", self.as_str().to_owned())
     }
 }
 
@@ -551,6 +523,15 @@ impl XDNSPrefetchControl {
     }
 }
 
+impl XDNSPrefetchControl {
+    fn as_str(&self) -> &'static str {
+        match self {
+            XDNSPrefetchControl::Off => "off",
+            XDNSPrefetchControl::On => "on",
+        }
+    }
+}
+
 impl Display for XDNSPrefetchControl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -560,13 +541,9 @@ impl Display for XDNSPrefetchControl {
     }
 }
 
-impl Header for XDNSPrefetchControl {
-    fn name(&self) -> &'static str {
-        "X-DNS-Prefetch-Control"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for XDNSPrefetchControl {
+    fn into(self) -> Header {
+        ("X-DNS-Prefetch-Control", self.as_str().to_owned())
     }
 }
 
@@ -596,6 +573,14 @@ impl XDownloadOptions {
     }
 }
 
+impl XDownloadOptions {
+    fn as_str(&self) -> &'static str {
+        match self {
+            XDownloadOptions::NoOpen => "noopen",
+        }
+    }
+}
+
 impl Display for XDownloadOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -604,13 +589,9 @@ impl Display for XDownloadOptions {
     }
 }
 
-impl Header for XDownloadOptions {
-    fn name(&self) -> &'static str {
-        "X-Download-Options"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for XDownloadOptions {
+    fn into(self) -> Header {
+        ("X-Download-Options", self.as_str().to_owned())
     }
 }
 
@@ -667,13 +648,9 @@ impl Display for XFrameOptions {
     }
 }
 
-impl Header for XFrameOptions {
-    fn name(&self) -> &'static str {
-        "X-Frame-Options"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for XFrameOptions {
+    fn into(self) -> Header {
+        ("X-Frame-Options", self.to_string())
     }
 }
 
@@ -735,6 +712,18 @@ impl XPermittedCrossDomainPolicies {
     }
 }
 
+impl XPermittedCrossDomainPolicies {
+    fn as_str(&self) -> &'static str {
+        match self {
+            XPermittedCrossDomainPolicies::None => "none",
+            XPermittedCrossDomainPolicies::MasterOnly => "master-only",
+            XPermittedCrossDomainPolicies::ByContentType => "by-content-type",
+            XPermittedCrossDomainPolicies::ByFtpFilename => "by-ftp-filename",
+            XPermittedCrossDomainPolicies::All => "all",
+        }
+    }
+}
+
 impl Display for XPermittedCrossDomainPolicies {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -747,13 +736,12 @@ impl Display for XPermittedCrossDomainPolicies {
     }
 }
 
-impl Header for XPermittedCrossDomainPolicies {
-    fn name(&self) -> &'static str {
-        "X-Permitted-Cross-Domain-Policies"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for XPermittedCrossDomainPolicies {
+    fn into(self) -> Header {
+        (
+            "X-Permitted-Cross-Domain-Policies",
+            self.as_str().to_owned(),
+        )
     }
 }
 
@@ -839,13 +827,9 @@ impl Display for XXSSProtection {
     }
 }
 
-impl Header for XXSSProtection {
-    fn name(&self) -> &'static str {
-        "X-XSS-Protection"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for XXSSProtection {
+    fn into(self) -> Header {
+        ("X-XSS-Protection", self.to_string())
     }
 }
 
@@ -879,13 +863,9 @@ impl Display for XPoweredBy {
     }
 }
 
-impl Header for XPoweredBy {
-    fn name(&self) -> &'static str {
-        "X-Powered-By"
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for XPoweredBy {
+    fn into(self) -> Header {
+        ("X-Powered-By", self.to_string())
     }
 }
 
@@ -1436,17 +1416,16 @@ impl Default for ContentSecurityPolicy<'_> {
     }
 }
 
-impl Header for ContentSecurityPolicy<'_> {
-    fn name(&self) -> &'static str {
-        if self.report_only {
-            "Content-Security-Policy-Report-Only"
-        } else {
-            "Content-Security-Policy"
-        }
-    }
-
-    fn value(&self) -> String {
-        self.to_string()
+impl Into<Header> for ContentSecurityPolicy<'_> {
+    fn into(self) -> Header {
+        (
+            if self.report_only {
+                "Content-Security-Policy-Report-Only"
+            } else {
+                "Content-Security-Policy"
+            },
+            self.to_string(),
+        )
     }
 }
 
@@ -1468,8 +1447,10 @@ impl Header for ContentSecurityPolicy<'_> {
 /// let helmet = Helmet::new()
 ///    .add(StrictTransportSecurity::new().max_age(31536000).include_sub_domains());
 /// ```
+
+#[derive(Clone)]
 pub struct Helmet {
-    pub headers: Vec<Box<dyn Header>>,
+    pub headers: Vec<Header>,
 }
 
 #[allow(clippy::should_implement_trait)]
@@ -1482,8 +1463,8 @@ impl Helmet {
     }
 
     /// Add header to the middleware
-    pub fn add(mut self, header: impl Header + 'static) -> Self {
-        self.headers.push(Box::new(header));
+    pub fn add(mut self, header: impl Into<Header>) -> Self {
+        self.headers.push(header.into());
         self
     }
 }

--- a/packages/ntex-helmet/Cargo.toml
+++ b/packages/ntex-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntex-helmet"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for ntex-web"
@@ -15,7 +15,7 @@ categories = ["web-programming", "http", "middleware"]
 
 [dependencies]
 ntex = { version = "2.12", features = ["tokio"] }
-helmet-core = { path = "../helmet-core", version = "0.1.0" }
+helmet-core = { path = "../helmet-core", version = "0.2.0" }
 
 [dev-dependencies]
 ntex = { version = "2.12", features = ["tokio"] }


### PR DESCRIPTION
## Simplify Core

- Changed `Header` from a `trait` to a type alias for `(&'static str, String)`
  - Removes need for `Box::new` in `Helmet` constructor

## Added `actix_web` crate

- Allows using `Helmet` in Actix

## Updated NTex to v2

## Breaking change

- This is a breaking change so all crates are bumped to `0.2.0`