### PR TITLE
feat!: v1.0.0 - stabilise API with security improvements

### DIFF
--- a/packages/actix-web-helmet/Cargo.toml
+++ b/packages/actix-web-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-helmet"
-version = "0.3.1"
+version = "1.0.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for actix-web"
@@ -19,7 +19,7 @@ categories = [
 
 [dependencies]
 actix-web = { version = "4.13" }
-helmet-core = { path = "../helmet-core", version = "0.3.0" }
+helmet-core = { path = "../helmet-core", version = "1.0.0" }
 futures = { version = "0.3" }
 
 [dev-dependencies]

--- a/packages/actix-web-helmet/src/lib.rs
+++ b/packages/actix-web-helmet/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```no_run
 //! use actix_web::{web, App, HttpServer, Responder, get};
-//! use actix_web_helmet::Helmet;
+//! use actix_web_helmet::{Helmet, HelmetMiddleware};
 //!
 //! #[get("/")]
 //! async fn index() -> impl Responder {
@@ -17,7 +17,8 @@
 //!
 //! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
-//!  HttpServer::new(|| App::new().wrap(Helmet::default()).service(index))
+//!  let helmet: HelmetMiddleware = Helmet::default().try_into().expect("valid headers");
+//!  HttpServer::new(move || App::new().wrap(helmet.clone()).service(index))
 //!      .bind(("127.0.0.1", 8080))?
 //!      .run()
 //!      .await
@@ -47,11 +48,11 @@
 //!
 //! By default if you construct a new instance of `Helmet` it will not set any headers.
 //!
-//! It is possible to configure `Helmet` to set only the headers you want, by using the `add` method to add headers.
+//! It is possible to configure `Helmet` to set only the headers you want, by using the `add` method.
 //!
 //! ```no_run
 //! use actix_web::{get, web, App, HttpServer, Responder};
-//! use actix_web_helmet::{Helmet, ContentSecurityPolicy, CrossOriginOpenerPolicy};
+//! use actix_web_helmet::{Helmet, HelmetMiddleware, ContentSecurityPolicy, CrossOriginOpenerPolicy};
 //!
 //! #[get("/")]
 //! async fn index() -> impl Responder {
@@ -60,22 +61,21 @@
 //!
 //! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
-//!     HttpServer::new(|| {
-//!         {
-//!             App::new().wrap(
-//!                 Helmet::new()
-//!                     .add(
-//!                         ContentSecurityPolicy::new()
-//!                             .child_src(vec!["'self'"])
-//!                             .child_src(vec!["'self'", "https://youtube.com"])
-//!                             .connect_src(vec!["'self'", "https://youtube.com"])
-//!                             .default_src(vec!["'self'", "https://youtube.com"])
-//!                             .font_src(vec!["'self'", "https://youtube.com"]),
-//!                     )
-//!                     .add(CrossOriginOpenerPolicy::same_origin_allow_popups()),
-//!             )
-//!         }
-//!         .service(index)
+//!     let helmet: HelmetMiddleware = Helmet::new()
+//!         .add(
+//!             ContentSecurityPolicy::new()
+//!                 .child_src(vec!["'self'"])
+//!                 .child_src(vec!["'self'", "https://youtube.com"])
+//!                 .connect_src(vec!["'self'", "https://youtube.com"])
+//!                 .default_src(vec!["'self'", "https://youtube.com"])
+//!                 .font_src(vec!["'self'", "https://youtube.com"]),
+//!         )
+//!         .add(CrossOriginOpenerPolicy::same_origin_allow_popups())
+//!         .try_into()
+//!         .expect("valid headers");
+//!
+//!     HttpServer::new(move || {
+//!         App::new().wrap(helmet.clone()).service(index)
 //!     })
 //!     .bind(("127.0.0.1", 8080))?
 //!     .run()
@@ -95,15 +95,17 @@ use helmet_core::Helmet as HelmetCore;
 // re-export helmet_core::*, except for the `Helmet` struct
 pub use helmet_core::*;
 
-pub struct HelmetMiddleware<S> {
-    inner: HelmetCore,
-    service: S,
-}
-
-/// Helmet middleware
+/// Helmet header configuration wrapper.
+///
+/// Use `Helmet::default()` for a sensible set of default security headers,
+/// or `Helmet::new()` to start with no headers and add only the ones you need.
+///
+/// Convert to [`HelmetMiddleware`] via `try_into()` to use as actix-web middleware.
+///
 /// ```rust
-/// use actix_web::{web, App, HttpServer};
-/// use actix_web_helmet::Helmet;
+/// use actix_web_helmet::{Helmet, HelmetMiddleware};
+///
+/// let mw: HelmetMiddleware = Helmet::default().try_into().unwrap();
 /// ```
 #[derive(Default)]
 pub struct Helmet(HelmetCore);
@@ -114,50 +116,67 @@ impl Helmet {
         Self(HelmetCore::new())
     }
 
-    /// Add a header to the middleware.
+    /// Add a header.
     #[allow(clippy::should_implement_trait)]
-    pub fn add(self, middleware: impl Into<helmet_core::Header>) -> Self {
-        Self(self.0.add(middleware))
+    pub fn add(self, header: impl Into<helmet_core::Header>) -> Self {
+        Self(self.0.add(header))
+    }
+
+    pub fn into_middleware(self) -> Result<HelmetMiddleware, HelmetError> {
+        self.try_into()
     }
 }
 
-impl<S, B> Transform<S, ServiceRequest> for Helmet
+/// The actix-web middleware created by converting a [`Helmet`] configuration.
+#[derive(Clone)]
+pub struct HelmetMiddleware {
+    headers: Vec<(HeaderName, HeaderValue)>,
+}
+
+impl TryFrom<Helmet> for HelmetMiddleware {
+    type Error = HelmetError;
+
+    fn try_from(helmet: Helmet) -> Result<Self, Self::Error> {
+        let mut headers = Vec::new();
+        for header in helmet.0.headers.iter() {
+            let name = HeaderName::from_bytes(header.0.as_bytes())
+                .map_err(|_| HelmetError::InvalidHeaderName(header.0.to_string()))?;
+            let value = HeaderValue::from_str(&header.1)
+                .map_err(|_| HelmetError::InvalidHeaderValue(header.1.clone()))?;
+            headers.push((name, value));
+        }
+        Ok(Self { headers })
+    }
+}
+
+pub struct HelmetService<S> {
+    headers: Vec<(HeaderName, HeaderValue)>,
+    service: S,
+}
+
+impl<S, B> Transform<S, ServiceRequest> for HelmetMiddleware
 where
-    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static, // Add 'static bound
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
     S::Future: 'static,
     B: 'static,
 {
     type Response = ServiceResponse<B>;
     type Error = Error;
     type InitError = ();
-    // The actual middleware service that will be created
-    type Transform = HelmetMiddleware<S>;
-    // The future that resolves to the middleware service
+    type Transform = HelmetService<S>;
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
-        // Create the middleware service instance HelmetMiddleware
-        // Clone the inner configuration (HelmetCore).
-        // HelmetCore should derive Clone or you might need to wrap it in Rc/Arc.
-        // Assuming HelmetCore is Clone:
-        ok(HelmetMiddleware {
-            inner: self.0.clone(), // Clone the configuration from the factory
-            service,               // Pass the next service in the chain
+        ok(HelmetService {
+            headers: self.headers.clone(),
+            service,
         })
-
-        // If HelmetCore is large and not Clone, you might wrap it in Rc in the Helmet struct:
-        // pub struct Helmet(Rc<HelmetCore>);
-        // And then clone the Rc here:
-        // ok(HelmetMiddleware {
-        //     inner: self.0.clone(),
-        //     service,
-        // })
     }
 }
 
 type LocalBoxFuture<T> = Pin<Box<dyn Future<Output = T> + 'static>>;
 
-impl<S, B> Service<ServiceRequest> for HelmetMiddleware<S>
+impl<S, B> Service<ServiceRequest> for HelmetService<S>
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     S::Future: 'static,
@@ -167,28 +186,17 @@ where
     type Error = Error;
     type Future = LocalBoxFuture<Result<Self::Response, Self::Error>>;
 
-    // This service is ready when its next service is ready
     forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
         let fut = self.service.call(req);
-
-        let headers_vec = self
-            .inner
-            .headers
-            .iter()
-            .map(|header| (header.0, header.1.clone()))
-            .collect::<Vec<_>>();
+        let headers = self.headers.clone();
 
         Box::pin(async move {
             let mut res = fut.await?;
 
-            // Set the headers
-            for (name, value) in &headers_vec {
-                res.headers_mut().insert(
-                    HeaderName::from_bytes(name.as_bytes()).unwrap(),
-                    HeaderValue::from_str(value).unwrap(),
-                );
+            for (name, value) in &headers {
+                res.headers_mut().insert(name.clone(), value.clone());
             }
             Ok(res)
         })
@@ -198,35 +206,28 @@ where
 #[cfg(test)]
 mod tests {
     use actix_web::http::header::{HeaderName, HeaderValue};
-    // Make sure HttpResponse is imported if not already
-    use actix_web::{http, test, web, App, HttpResponse}; // Added test, http, HttpResponse
+    use actix_web::{http, test, web, App, HttpResponse};
 
-    use super::*; // Keep this
+    use super::*;
 
     #[actix_web::test]
     async fn test_helmet() {
-        // 1. Create the middleware *factory* instance
-        let helmet_factory =
-            Helmet::new().add(ContentSecurityPolicy::new().child_src(vec!["'self'"]));
-
-        // 2. Initialize the service using the factory with .wrap()
         let app = test::init_service(
-            // Use test::init_service
             App::new()
-                .wrap(helmet_factory) // Use the factory here
-                // Define a simple async route correctly
+                .wrap(
+                    Helmet::new()
+                        .add(ContentSecurityPolicy::new().child_src(vec!["'self'"]))
+                        .into_middleware()
+                        .unwrap(),
+                )
                 .route("/", web::get().to(|| async { HttpResponse::Ok().finish() })),
         )
         .await;
 
-        // 3. Create a request
-        let req = test::TestRequest::get().uri("/").to_request(); // Use test::TestRequest
+        let req = test::TestRequest::get().uri("/").to_request();
+        let res = test::call_service(&app, req).await;
 
-        // 4. Call the service
-        let res = test::call_service(&app, req).await; // Use test::call_service and the app
-
-        // 5. Assertions
-        assert!(res.status().is_success()); // Check status code idiomatically
+        assert!(res.status().is_success());
         assert_eq!(
             res.headers()
                 .get(HeaderName::from_static("content-security-policy")),
@@ -234,12 +235,13 @@ mod tests {
         );
     }
 
-    // Optional: Add a test for the default configuration
     #[actix_web::test]
     async fn test_helmet_default() {
+        let helmet: HelmetMiddleware = Helmet::default().try_into().unwrap();
+
         let app = test::init_service(
             App::new()
-                .wrap(Helmet::default()) // Use the default factory
+                .wrap(helmet)
                 .route("/", web::get().to(|| async { HttpResponse::Ok().finish() })),
         )
         .await;
@@ -248,9 +250,8 @@ mod tests {
         let resp = test::call_service(&app, req).await;
 
         assert!(resp.status().is_success());
-        // Check one or two default headers to confirm it works
         assert_eq!(
-            resp.headers().get(http::header::X_FRAME_OPTIONS), // Use constants from http::header
+            resp.headers().get(http::header::X_FRAME_OPTIONS),
             Some(&HeaderValue::from_static("SAMEORIGIN"))
         );
         assert_eq!(

--- a/packages/axum-helmet/Cargo.toml
+++ b/packages/axum-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-helmet"
-version = "0.3.1"
+version = "1.0.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware core for axum web framework"
@@ -19,7 +19,7 @@ categories = [
 
 [dependencies]
 axum = "0.8"
-helmet-core = { path = "../helmet-core", version = "0.3.0" }
+helmet-core = { path = "../helmet-core", version = "1.0.0" }
 tower = "0.5"
 tower-service = "0.3"
 http = "1.4"

--- a/packages/axum-helmet/src/lib.rs
+++ b/packages/axum-helmet/src/lib.rs
@@ -5,18 +5,13 @@
 //! ```no_run
 //! use axum::{routing::get, Router};
 //! use axum_helmet::{Helmet, HelmetLayer};
-//! use helmet_core::Helmet as HelmetCore;
 //!
 //! #[tokio::main]
 //! async fn main() {
+//!     let layer: HelmetLayer = Helmet::default().try_into().unwrap();
 //!     let app = Router::new()
 //!         .route("/", get(|| async { "Hello, world!" }))
-//!         .layer(HelmetLayer::new(
-//!             Helmet::new()
-//!                 .add(helmet_core::XContentTypeOptions::nosniff())
-//!                 .add(helmet_core::XFrameOptions::same_origin())
-//!                 .add(helmet_core::XXSSProtection::on().mode_block()),
-//!         ));
+//!         .layer(layer);
 //!
 //!     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
 //!     axum::serve(listener, app).await.unwrap();
@@ -37,8 +32,39 @@ use helmet_core::Helmet as HelmetCore;
 // re-export helmet_core::* for convenience
 pub use helmet_core::*;
 
+/// Helmet header configuration wrapper.
+///
+/// Use `Helmet::default()` for a sensible set of default security headers,
+/// or `Helmet::new()` to start with no headers and add only the ones you need.
+///
+/// Convert to [`HelmetLayer`] via `try_into()` to use as axum middleware.
+///
+/// ```rust
+/// use axum_helmet::{Helmet, HelmetLayer};
+///
+/// let layer: HelmetLayer = Helmet::default().try_into().unwrap();
+/// ```
+#[derive(Default)]
+pub struct Helmet(HelmetCore);
+
+impl Helmet {
+    /// Create a new instance of `Helmet` with no headers set.
+    pub fn new() -> Self {
+        Self(HelmetCore::new())
+    }
+
+    /// Add a header.
+    #[allow(clippy::should_implement_trait)]
+    pub fn add(self, header: impl Into<helmet_core::Header>) -> Self {
+        Self(self.0.add(header))
+    }
+
+    pub fn into_layer(self) -> Result<HelmetLayer, HelmetError> {
+        self.try_into()
+    }
+}
+
 /// Create a [`tower::layer::Layer`] that adds helmet headers to responses.
-/// See [`helmet_core::Helmet`] for more details.
 ///
 /// # Example
 ///
@@ -48,14 +74,16 @@ pub use helmet_core::*;
 ///
 /// #[tokio::main]
 /// async fn main() {
+///     let layer: HelmetLayer = Helmet::new()
+///         .add(helmet_core::XContentTypeOptions::nosniff())
+///         .add(helmet_core::XFrameOptions::same_origin())
+///         .add(helmet_core::XXSSProtection::on().mode_block())
+///         .try_into()
+///         .unwrap();
+///
 ///     let app = Router::new()
 ///         .route("/", get(|| async { "Hello, world!" }))
-///         .layer(HelmetLayer::new(
-///             Helmet::new()
-///                 .add(helmet_core::XContentTypeOptions::nosniff())
-///                 .add(helmet_core::XFrameOptions::same_origin())
-///                 .add(helmet_core::XXSSProtection::on().mode_block()),
-///         ));
+///         .layer(layer);
 ///
 ///     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
 ///     axum::serve(listener, app).await.unwrap();
@@ -66,19 +94,19 @@ pub struct HelmetLayer {
     headers: HeaderMap,
 }
 
-impl HelmetLayer {
-    pub fn new(core: HelmetCore) -> Self {
-        let headers = core
-            .headers
-            .iter()
-            .map(|header| {
-                (
-                    HeaderName::try_from(header.0).expect("invalid header name"),
-                    HeaderValue::try_from(&header.1).expect("invalid header value"),
-                )
-            })
-            .collect();
-        Self { headers }
+impl TryFrom<Helmet> for HelmetLayer {
+    type Error = HelmetError;
+
+    fn try_from(helmet: Helmet) -> Result<Self, Self::Error> {
+        let mut headers = HeaderMap::new();
+        for header in helmet.0.headers.iter() {
+            let name = HeaderName::try_from(header.0)
+                .map_err(|_| HelmetError::InvalidHeaderName(header.0.to_string()))?;
+            let value = HeaderValue::try_from(&header.1)
+                .map_err(|_| HelmetError::InvalidHeaderValue(header.1.clone()))?;
+            headers.insert(name, value);
+        }
+        Ok(Self { headers })
     }
 }
 
@@ -96,14 +124,6 @@ impl<S> tower::layer::Layer<S> for HelmetLayer {
 pub struct HelmetInner<S> {
     header_map: HeaderMap,
     inner: S,
-}
-
-impl<S> HelmetInner<S> {
-    pub fn new(inner: S) -> Self {
-        let header_map = HeaderMap::new();
-
-        Self { header_map, inner }
-    }
 }
 
 impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for HelmetInner<S>
@@ -128,7 +148,7 @@ where
 }
 
 pin_project! {
-    /// Response future for [`SetResponseHeader`].
+    /// Response future for [`HelmetInner`].
     #[derive(Debug)]
     pub struct ResponseFuture<F> {
         #[pin]
@@ -147,8 +167,9 @@ where
         let this = self.project();
         let mut res = ready!(this.future.poll(cx)?);
 
-        res.headers_mut()
-            .extend(this.headers.iter().map(|(k, v)| (k.clone(), v.clone())));
+        for (name, value) in this.headers.iter() {
+            res.headers_mut().insert(name.clone(), value.clone());
+        }
 
         Poll::Ready(Ok(res))
     }
@@ -166,12 +187,14 @@ mod tests {
     async fn test_helmet() {
         let test_app = Router::new()
             .route("/", get(|| async { "Hello, world!" }))
-            .layer(HelmetLayer::new(
+            .layer(
                 Helmet::new()
                     .add(helmet_core::XContentTypeOptions::nosniff())
                     .add(helmet_core::XFrameOptions::same_origin())
-                    .add(helmet_core::XXSSProtection::on().mode_block()),
-            ));
+                    .add(helmet_core::XXSSProtection::on().mode_block())
+                    .into_layer()
+                    .unwrap(),
+            );
 
         let server = TestServer::new(test_app);
 

--- a/packages/helmet-core/Cargo.toml
+++ b/packages/helmet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helmet-core"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware core for various web frameworks"

--- a/packages/helmet-core/src/lib.rs
+++ b/packages/helmet-core/src/lib.rs
@@ -602,7 +602,7 @@ impl From<XDownloadOptions> for Header {
 ///
 /// - deny: The page cannot be displayed in a frame, regardless of the site attempting to do so.
 /// - sameorigin: The page can only be displayed in a frame on the same origin as the page itself.
-/// - allow-from: The page can only be displayed in a frame on the specified origin. Requires a URI as an argument.
+/// - allow-from: **Deprecated.** Ignored by all modern browsers. Use `ContentSecurityPolicy::new().frame_ancestors(...)` instead.
 ///
 /// # Examples
 ///
@@ -612,14 +612,14 @@ impl From<XDownloadOptions> for Header {
 /// let x_frame_options = XFrameOptions::deny();
 ///
 /// let x_frame_options = XFrameOptions::same_origin();
-///
-/// let x_frame_options = XFrameOptions::allow_from("https://example.com");
 /// ```
 #[derive(Clone)]
 pub enum XFrameOptions {
     Deny,
     SameOrigin,
-    // deprecated - use Content-Security-Policy instead see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#allow-from_origin
+    #[deprecated(
+        note = "ALLOW-FROM is ignored by modern browsers. Use ContentSecurityPolicy::new().frame_ancestors(...) instead."
+    )]
     AllowFrom(String),
 }
 
@@ -632,13 +632,18 @@ impl XFrameOptions {
         Self::SameOrigin
     }
 
+    #[deprecated(
+        note = "ALLOW-FROM is ignored by modern browsers. Use ContentSecurityPolicy::new().frame_ancestors(...) instead."
+    )]
     pub fn allow_from(uri: &str) -> Self {
+        #[allow(deprecated)]
         Self::AllowFrom(uri.to_string())
     }
 }
 
 impl Display for XFrameOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(deprecated)]
         match self {
             XFrameOptions::Deny => write!(f, "DENY"),
             XFrameOptions::SameOrigin => write!(f, "SAMEORIGIN"),
@@ -892,7 +897,8 @@ impl From<XPoweredBy> for Header {
 /// - sandbox: Enables a sandbox for the requested resource similar to the iframe sandbox attribute. The sandbox applies a same origin policy, prevents popups, plugins and script execution is blocked. You can keep the sandbox value empty to keep all restrictions in place, or add values: allow-forms allow-same-origin allow-scripts allow-popups, allow-modals, allow-orientation-lock, allow-pointer-lock, allow-presentation, allow-popups-to-escape-sandbox, allow-top-navigation, allow-top-navigation-by-user-activation.
 /// - form-action: Restricts the URLs which can be used as the target of a form submissions from a given context.
 /// - frame-ancestors: Specifies valid parents that may embed a page using `<frame>`, `<iframe>`, `<object>`, `<embed>`, or `<applet>`.
-/// - report-to: Enables reporting of violations.
+/// - report-to: Specifies the endpoint name (defined via `Reporting-Endpoints` header) to send violation reports to.
+/// - report-uri: Specifies URL(s) to send violation reports to (deprecated but still widely supported).
 /// - require-trusted-types-for: Specifies which trusted types are required by a resource.
 /// - trusted-types: Specifies which trusted types are defined by a resource.
 /// - upgrade-insecure-requests: Block HTTP requests on insecure elements.
@@ -913,14 +919,15 @@ impl From<XPoweredBy> for Header {
 ///
 /// In report only mode, the browser will not block the request, but will send a report to the specified URI.
 ///
-/// Make sure to set the `report-to` directive.
+/// Make sure to set the `report-to` and/or `report-uri` directives.
 ///
 /// ```
 /// use helmet_core::ContentSecurityPolicy;
 ///
 /// let content_security_policy = ContentSecurityPolicy::default()
 ///    .child_src(vec!["'self'", "https://youtube.com"])
-///    .report_to(vec!["https://example.com/report"])
+///    .report_to("csp-endpoint")
+///    .report_uri(vec!["https://example.com/report"])
 ///    .report_only();
 /// ```
 #[derive(Clone)]
@@ -946,7 +953,8 @@ pub struct ContentSecurityPolicy<'a> {
     sandbox: Option<Vec<&'a str>>,
     form_action: Option<Vec<&'a str>>,
     frame_ancestors: Option<Vec<&'a str>>,
-    report_to: Option<Vec<&'a str>>,
+    report_to: Option<&'a str>,
+    report_uri: Option<Vec<&'a str>>,
     require_trusted_types_for: Option<Vec<&'a str>>,
     trusted_types: Option<Vec<&'a str>>,
     upgrade_insecure_requests: bool,
@@ -978,6 +986,7 @@ impl<'a> ContentSecurityPolicy<'a> {
             form_action: None,
             frame_ancestors: None,
             report_to: None,
+            report_uri: None,
             require_trusted_types_for: None,
             trusted_types: None,
             upgrade_insecure_requests: false,
@@ -1111,9 +1120,15 @@ impl<'a> ContentSecurityPolicy<'a> {
         self
     }
 
-    /// report-to: Enables reporting of violations.
-    pub fn report_to(mut self, values: Vec<&'a str>) -> Self {
-        self.report_to = Some(values);
+    /// report-to: Specifies the endpoint name (defined via `Reporting-Endpoints` header) to send violation reports to.
+    pub fn report_to(mut self, endpoint: &'a str) -> Self {
+        self.report_to = Some(endpoint);
+        self
+    }
+
+    /// report-uri: Specifies URL(s) to send violation reports to (deprecated but still widely supported).
+    pub fn report_uri(mut self, values: Vec<&'a str>) -> Self {
+        self.report_uri = Some(values);
         self
     }
 
@@ -1217,8 +1232,10 @@ impl Display for ContentSecurityPolicy<'_> {
             directives.push(directive("sandbox", v));
         }
         if let Some(v) = &self.report_to {
-            let values = v.join(" ");
-            directives.push(format!("report-to {}; report-uri {}", values, values));
+            directives.push(format!("report-to {}", v));
+        }
+        if let Some(v) = &self.report_uri {
+            directives.push(directive("report-uri", v));
         }
         if let Some(v) = &self.require_trusted_types_for {
             directives.push(directive("require-trusted-types-for", v));
@@ -1280,6 +1297,26 @@ impl From<ContentSecurityPolicy<'_>> for Header {
     }
 }
 
+/// Error returned when a header name or value cannot be converted to a valid HTTP header.
+#[derive(Debug)]
+pub enum HelmetError {
+    /// The header name is not a valid HTTP header name.
+    InvalidHeaderName(String),
+    /// The header value is not a valid HTTP header value.
+    InvalidHeaderValue(String),
+}
+
+impl std::fmt::Display for HelmetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HelmetError::InvalidHeaderName(name) => write!(f, "invalid header name: {}", name),
+            HelmetError::InvalidHeaderValue(msg) => write!(f, "invalid header value: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for HelmetError {}
+
 /// Helmet security headers middleware for ntex services
 ///
 /// # Examples
@@ -1298,7 +1335,6 @@ impl From<ContentSecurityPolicy<'_>> for Header {
 /// let helmet = Helmet::new()
 ///    .add(StrictTransportSecurity::new().max_age(31536000).include_sub_domains());
 /// ```
-
 #[derive(Clone)]
 pub struct Helmet {
     pub headers: Vec<Header>,

--- a/packages/ntex-helmet/Cargo.toml
+++ b/packages/ntex-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntex-helmet"
-version = "0.4.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for ntex-web"
@@ -19,7 +19,7 @@ categories = [
 
 [dependencies]
 ntex = { version = "3", features = ["tokio"] }
-helmet-core = { path = "../helmet-core", version = "0.3.0" }
+helmet-core = { path = "../helmet-core", version = "1.0.0" }
 
 [dev-dependencies]
 ntex = { version = "3", features = ["tokio"] }

--- a/packages/ntex-helmet/src/lib.rs
+++ b/packages/ntex-helmet/src/lib.rs
@@ -8,14 +8,19 @@
 //!
 //! ```no_run
 //! use ntex::web;
-//! use ntex_helmet::Helmet;
+//! use ntex_helmet::{Helmet, HelmetMiddleware};
 //!
 //! #[ntex::main]
 //! async fn main() -> std::io::Result<()> {
-//!     web::HttpServer::new(move || async {
-//!         web::App::new()
-//!            .middleware(Helmet::default())
-//!            .service(web::resource("/").to(|| async { "Hello, world!" }))
+//!     let handler: HelmetMiddleware = Helmet::default().try_into().unwrap();
+//!
+//!     web::HttpServer::new(move || {
+//!         let handler = handler.clone();
+//!         async move {
+//!             web::App::new()
+//!                .middleware(handler)
+//!                .service(web::resource("/").to(|| async { "Hello, world!" }))
+//!         }
 //!     })
 //!     .bind(("127.0.0.1", 8080))?
 //!     .run()
@@ -50,24 +55,29 @@
 //!
 //! ```no_run
 //! use ntex::web;
-//! use ntex_helmet::{ContentSecurityPolicy, CrossOriginOpenerPolicy, Helmet};
+//! use ntex_helmet::{ContentSecurityPolicy, CrossOriginOpenerPolicy, Helmet, HelmetMiddleware};
 //!
 //! #[ntex::main]
 //! async fn main() -> std::io::Result<()> {
-//!     web::HttpServer::new(move || async {
-//!         web::App::new()
-//!             .middleware(
-//!                 Helmet::new()
-//!                     .add(
-//!                         ContentSecurityPolicy::new()
-//!                             .child_src(vec!["'self'", "https://youtube.com"])
-//!                             .connect_src(vec!["'self'", "https://youtube.com"])
-//!                             .default_src(vec!["'self'", "https://youtube.com"])
-//!                             .font_src(vec!["'self'", "https://youtube.com"]),
-//!                     )
-//!                     .add(CrossOriginOpenerPolicy::same_origin_allow_popups()),
-//!             )
-//!             .service(web::resource("/").to(|| async { "Hello, world!" }))
+//!     let handler: HelmetMiddleware = Helmet::new()
+//!         .add(
+//!             ContentSecurityPolicy::new()
+//!                 .child_src(vec!["'self'", "https://youtube.com"])
+//!                 .connect_src(vec!["'self'", "https://youtube.com"])
+//!                 .default_src(vec!["'self'", "https://youtube.com"])
+//!                 .font_src(vec!["'self'", "https://youtube.com"]),
+//!         )
+//!         .add(CrossOriginOpenerPolicy::same_origin_allow_popups())
+//!         .try_into()
+//!         .unwrap();
+//!
+//!     web::HttpServer::new(move || {
+//!         let handler = handler.clone();
+//!         async move {
+//!             web::App::new()
+//!                 .middleware(handler)
+//!                 .service(web::resource("/").to(|| async { "Hello, world!" }))
+//!         }
 //!     })
 //!     .bind(("127.0.0.1", 4200))?
 //!     .run()
@@ -89,12 +99,81 @@ use helmet_core::Helmet as HelmetCore;
 // re-export helmet_core::*, except for the `Helmet` struct
 pub use helmet_core::*;
 
-pub struct HelmetMiddleware<S> {
+/// Helmet header configuration wrapper.
+///
+/// Use `Helmet::default()` for a sensible set of default security headers,
+/// or `Helmet::new()` to start with no headers and add only the ones you need.
+///
+/// Convert to [`HelmetMiddleware`] via `try_into()` to use as ntex middleware.
+///
+/// ```rust
+/// use ntex_helmet::{Helmet, HelmetMiddleware};
+///
+/// let mw: HelmetMiddleware = Helmet::default().try_into().unwrap();
+/// ```
+#[derive(Default)]
+pub struct Helmet(HelmetCore);
+
+impl Helmet {
+    /// Create a new instance of `Helmet` with no headers set.
+    pub fn new() -> Self {
+        Self(HelmetCore::new())
+    }
+
+    /// Add a header.
+    #[allow(clippy::should_implement_trait)]
+    pub fn add(self, header: impl Into<helmet_core::Header>) -> Self {
+        Self(self.0.add(header))
+    }
+
+    /// Convert into [`HelmetMiddleware`].
+    ///
+    /// This is equivalent to `HelmetMiddleware::try_from(helmet)` but chains
+    /// more naturally after `.add()` calls.
+    pub fn into_middleware(self) -> Result<HelmetMiddleware, HelmetError> {
+        self.try_into()
+    }
+}
+
+/// The ntex middleware created by converting a [`Helmet`] configuration.
+#[derive(Clone)]
+pub struct HelmetMiddleware {
+    headers: HeaderMap,
+}
+
+impl TryFrom<Helmet> for HelmetMiddleware {
+    type Error = HelmetError;
+
+    fn try_from(helmet: Helmet) -> Result<Self, Self::Error> {
+        let mut headers = HeaderMap::new();
+        for header in helmet.0.headers.iter() {
+            let name = HeaderName::try_from(header.0)
+                .map_err(|_| HelmetError::InvalidHeaderName(header.0.to_string()))?;
+            let value = HeaderValue::from_str(&header.1)
+                .map_err(|_| HelmetError::InvalidHeaderValue(header.1.clone()))?;
+            headers.insert(name, value);
+        }
+        Ok(Self { headers })
+    }
+}
+
+impl<S> Middleware<S, SharedCfg> for HelmetMiddleware {
+    type Service = HelmetService<S>;
+
+    fn create(&self, service: S, _: SharedCfg) -> Self::Service {
+        HelmetService {
+            service,
+            headers: self.headers.clone(),
+        }
+    }
+}
+
+pub struct HelmetService<S> {
     service: S,
     headers: HeaderMap,
 }
 
-impl<S, E> Service<WebRequest<E>> for HelmetMiddleware<S>
+impl<S, E> Service<WebRequest<E>> for HelmetService<S>
 where
     S: Service<WebRequest<E>, Response = WebResponse>,
     E: 'static,
@@ -109,45 +188,11 @@ where
     ) -> Result<Self::Response, Self::Error> {
         let mut res = ctx.call(&self.service, req).await?;
 
-        // set response headers
         for (name, value) in self.headers.iter() {
-            res.headers_mut().append(name.clone(), value.clone());
+            res.headers_mut().insert(name.clone(), value.clone());
         }
 
         Ok(res)
-    }
-}
-
-/// Helmet middleware
-/// ```rust
-/// use ntex::web;
-/// use ntex_helmet::Helmet;
-#[derive(Default)]
-pub struct Helmet(HelmetCore);
-
-#[allow(clippy::should_implement_trait)]
-impl Helmet {
-    pub fn new() -> Self {
-        Self(HelmetCore::new())
-    }
-
-    pub fn add(self, middleware: impl Into<helmet_core::Header>) -> Self {
-        Self(self.0.add(middleware))
-    }
-}
-
-impl<S> Middleware<S, SharedCfg> for Helmet {
-    type Service = HelmetMiddleware<S>;
-
-    fn create(&self, service: S, _: SharedCfg) -> Self::Service {
-        let mut headers = HeaderMap::new();
-        for header in self.0.headers.iter() {
-            let name = HeaderName::try_from(header.0).expect("invalid header name");
-            let value = HeaderValue::from_str(&header.1).expect("invalid header value");
-            headers.append(name, value);
-        }
-
-        HelmetMiddleware { service, headers }
     }
 }
 
@@ -172,6 +217,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(CrossOriginEmbedderPolicy::unsafe_none())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -188,6 +235,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(CrossOriginEmbedderPolicy::require_corp())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -204,6 +253,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(CrossOriginEmbedderPolicy::credentialless())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -220,6 +271,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(CrossOriginOpenerPolicy::same_origin())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -236,6 +289,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(CrossOriginOpenerPolicy::same_origin_allow_popups())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -252,6 +307,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(CrossOriginOpenerPolicy::unsafe_none())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -268,6 +325,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(CrossOriginResourcePolicy::same_origin())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -284,6 +343,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(CrossOriginResourcePolicy::cross_origin())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -300,6 +361,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(CrossOriginResourcePolicy::same_site())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -316,6 +379,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(OriginAgentCluster::new(true))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -336,6 +401,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(OriginAgentCluster::new(false))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -356,6 +423,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ReferrerPolicy::no_referrer())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -372,6 +441,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ReferrerPolicy::no_referrer_when_downgrade())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -388,6 +459,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ReferrerPolicy::origin())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -401,6 +474,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ReferrerPolicy::origin_when_cross_origin())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -419,6 +494,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ReferrerPolicy::same_origin())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -437,6 +514,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ReferrerPolicy::strict_origin())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -455,6 +534,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ReferrerPolicy::strict_origin_when_cross_origin())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -473,6 +554,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ReferrerPolicy::unsafe_url())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -488,6 +571,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(StrictTransportSecurity::new().max_age(31536000))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -513,6 +598,8 @@ mod tests {
                         .max_age(31536000)
                         .include_sub_domains(),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -534,6 +621,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(StrictTransportSecurity::new().max_age(31536000).preload())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -560,6 +649,8 @@ mod tests {
                         .include_sub_domains()
                         .preload(),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -581,6 +672,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XContentTypeOptions::nosniff())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -602,6 +695,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XDNSPrefetchControl::off())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -623,6 +718,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XDNSPrefetchControl::on())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -644,6 +741,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XDownloadOptions::noopen())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -665,6 +764,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XFrameOptions::deny())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -688,6 +789,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XFrameOptions::same_origin())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -707,10 +810,13 @@ mod tests {
     }
 
     #[ntex::test]
+    #[allow(deprecated)]
     async fn test_x_frame_options_allow_from() {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XFrameOptions::allow_from("https://example.com"))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -734,6 +840,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XPermittedCrossDomainPolicies::none())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -754,6 +862,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XPermittedCrossDomainPolicies::master_only())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -774,6 +884,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XPermittedCrossDomainPolicies::by_content_type())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -794,6 +906,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XPermittedCrossDomainPolicies::by_ftp_filename())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -816,6 +930,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XPermittedCrossDomainPolicies::all())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -836,6 +952,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XXSSProtection::off())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -850,6 +968,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XXSSProtection::on())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -866,6 +986,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XXSSProtection::on().mode_block())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -887,6 +1009,8 @@ mod tests {
                         .mode_block()
                         .report("https://example.com/report-xss-attack"),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -910,6 +1034,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::default())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -933,6 +1059,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(XPoweredBy::new("PHP 4.2.0"))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -947,6 +1075,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().child_src(vec!["'self'", "https://youtube.com"]))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -970,6 +1100,8 @@ mod tests {
                 .add(
                     ContentSecurityPolicy::new().connect_src(vec!["'self'", "https://youtube.com"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -993,6 +1125,8 @@ mod tests {
                 .add(
                     ContentSecurityPolicy::new().default_src(vec!["'self'", "https://youtube.com"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1013,6 +1147,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().font_src(vec!["'self'", "https://youtube.com"]))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1033,6 +1169,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().frame_src(vec!["'self'", "https://youtube.com"]))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1053,6 +1191,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().img_src(vec!["'self'", "https://youtube.com"]))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1072,6 +1212,8 @@ mod tests {
                     ContentSecurityPolicy::new()
                         .manifest_src(vec!["'self'", "https://youtube.com"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1088,6 +1230,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().media_src(vec!["'self'", "https://youtube.com"]))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1104,6 +1248,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().object_src(vec!["'self'", "https://youtube.com"]))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1123,6 +1269,8 @@ mod tests {
                     ContentSecurityPolicy::new()
                         .prefetch_src(vec!["'self'", "https://youtube.com"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1139,6 +1287,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().script_src(vec!["'self'", "https://youtube.com"]))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1158,6 +1308,8 @@ mod tests {
                     ContentSecurityPolicy::new()
                         .script_src_elem(vec!["'self'", "https://youtube.com"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1177,6 +1329,8 @@ mod tests {
                     ContentSecurityPolicy::new()
                         .script_src_attr(vec!["'self'", "https://youtube.com"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1193,6 +1347,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().style_src(vec!["'self'", "https://youtube.com"]))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1212,6 +1368,8 @@ mod tests {
                     ContentSecurityPolicy::new()
                         .style_src_attr(vec!["'self'", "https://youtube.com"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1231,6 +1389,8 @@ mod tests {
                     ContentSecurityPolicy::new()
                         .style_src_elem(vec!["'self'", "https://youtube.com"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1247,6 +1407,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().worker_src(vec!["'self'", "https://youtube.com"]))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1263,6 +1425,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().base_uri(vec!["'self'", "https://youtube.com"]))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1279,6 +1443,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().sandbox(vec!["allow-forms", "allow-scripts"]))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1297,6 +1463,8 @@ mod tests {
                 .add(
                     ContentSecurityPolicy::new().form_action(vec!["'self'", "https://youtube.com"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1318,6 +1486,8 @@ mod tests {
                     ContentSecurityPolicy::new()
                         .frame_ancestors(vec!["'self'", "https://youtube.com"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1335,7 +1505,9 @@ mod tests {
     async fn test_content_security_policy_report_to() {
         let mw = Pipeline::new(
             Helmet::new()
-                .add(ContentSecurityPolicy::new().report_to(vec!["default", "endpoint", "group"]))
+                .add(ContentSecurityPolicy::new().report_to("csp-endpoint"))
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1348,7 +1520,34 @@ mod tests {
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            "report-to default endpoint group; report-uri default endpoint group"
+            "report-to csp-endpoint"
+        );
+    }
+
+    #[ntex::test]
+    async fn test_content_security_policy_report_uri() {
+        let mw = Pipeline::new(
+            Helmet::new()
+                .add(
+                    ContentSecurityPolicy::new()
+                        .report_to("csp-endpoint")
+                        .report_uri(vec!["https://example.com/report"]),
+                )
+                .into_middleware()
+                .unwrap()
+                .create(ok_service(), SharedCfg::default()),
+        );
+
+        let req = TestRequest::default().to_srv_request();
+        let resp = mw.call(req).await.unwrap();
+
+        assert_eq!(
+            resp.headers()
+                .get("Content-Security-Policy")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "report-to csp-endpoint; report-uri https://example.com/report"
         );
     }
 
@@ -1360,6 +1559,8 @@ mod tests {
                     ContentSecurityPolicy::new()
                         .trusted_types(vec!["'self'", "https://youtube.com"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1383,6 +1584,8 @@ mod tests {
                 .add(
                     ContentSecurityPolicy::new().require_trusted_types_for(vec!["script", "style"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1404,6 +1607,8 @@ mod tests {
         let mw = Pipeline::new(
             Helmet::new()
                 .add(ContentSecurityPolicy::new().upgrade_insecure_requests())
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 
@@ -1417,7 +1622,12 @@ mod tests {
 
     #[ntex::test]
     async fn test_helmet_default() {
-        let mw = Pipeline::new(Helmet::default().create(ok_service(), SharedCfg::default()));
+        let mw = Pipeline::new(
+            Helmet::default()
+                .into_middleware()
+                .unwrap()
+                .create(ok_service(), SharedCfg::default()),
+        );
 
         let req = TestRequest::default().to_srv_request();
         let resp = mw.call(req).await.unwrap();
@@ -1467,6 +1677,8 @@ mod tests {
                         .report_only()
                         .base_uri(vec!["'self'"]),
                 )
+                .into_middleware()
+                .unwrap()
                 .create(ok_service(), SharedCfg::default()),
         );
 

--- a/packages/poem-helmet/Cargo.toml
+++ b/packages/poem-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poem-helmet"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for Poem web framework"
@@ -16,7 +16,7 @@ categories = [
 ]
 
 [dependencies]
-helmet-core = { path = "../helmet-core", version = "0.3.0" }
+helmet-core = { path = "../helmet-core", version = "1.0.0" }
 poem = "3"
 http = "1.4"
 

--- a/packages/poem-helmet/src/lib.rs
+++ b/packages/poem-helmet/src/lib.rs
@@ -16,14 +16,15 @@
 //! }
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), std::io::Error> {
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let app = Route::new()
 //!         .at("/", get(index))
-//!         .with(Helmet::default());
+//!         .with(Helmet::default().into_middleware()?);
 //!
 //!     Server::new(TcpListener::bind("0.0.0.0:3000"))
 //!         .run(app)
-//!         .await
+//!         .await?;
+//!     Ok(())
 //! }
 //! ```
 //!
@@ -54,7 +55,7 @@
 //!
 //! ```no_run
 //! use poem::{get, handler, listener::TcpListener, EndpointExt, Route, Server};
-//! use poem_helmet::{Helmet, ContentSecurityPolicy, CrossOriginOpenerPolicy};
+//! use poem_helmet::{Helmet, ContentSecurityPolicy, CrossOriginOpenerPolicy, HelmetMiddleware};
 //!
 //! #[handler]
 //! fn index() -> &'static str {
@@ -62,22 +63,24 @@
 //! }
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), std::io::Error> {
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let helmet: HelmetMiddleware = Helmet::new()
+//!         .add(
+//!             ContentSecurityPolicy::new()
+//!                 .default_src(vec!["'self'"])
+//!                 .script_src(vec!["'self'", "https://cdn.example.com"]),
+//!         )
+//!         .add(CrossOriginOpenerPolicy::same_origin_allow_popups())
+//!         .try_into()?;
+//!
 //!     let app = Route::new()
 //!         .at("/", get(index))
-//!         .with(
-//!             Helmet::new()
-//!                 .add(
-//!                     ContentSecurityPolicy::new()
-//!                         .default_src(vec!["'self'"])
-//!                         .script_src(vec!["'self'", "https://cdn.example.com"]),
-//!                 )
-//!                 .add(CrossOriginOpenerPolicy::same_origin_allow_popups()),
-//!         );
+//!         .with(helmet);
 //!
 //!     Server::new(TcpListener::bind("0.0.0.0:3000"))
 //!         .run(app)
-//!         .await
+//!         .await?;
+//!     Ok(())
 //! }
 //! ```
 use http::header::{HeaderMap, HeaderName, HeaderValue};
@@ -88,60 +91,66 @@ use helmet_core::Helmet as HelmetCore;
 // re-export helmet_core::*, except for the `Helmet` struct
 pub use helmet_core::*;
 
-/// Helmet middleware for Poem.
+/// Helmet header configuration wrapper.
 ///
 /// Use `Helmet::default()` for a sensible set of default security headers,
 /// or `Helmet::new()` to start with no headers and add only the ones you need.
 ///
-/// ```rust
-/// use poem_helmet::Helmet;
+/// Convert to [`HelmetMiddleware`] via `try_into()` to use as Poem middleware.
 ///
-/// let helmet = Helmet::default();
+/// ```rust
+/// use poem_helmet::{Helmet, HelmetMiddleware};
+///
+/// let middleware: HelmetMiddleware = Helmet::default().try_into().unwrap();
 /// ```
-pub struct Helmet {
-    headers: HeaderMap,
-}
-
-impl Default for Helmet {
-    fn default() -> Self {
-        Self::from(HelmetCore::default())
-    }
-}
+#[derive(Default)]
+pub struct Helmet(HelmetCore);
 
 impl Helmet {
     /// Create a new instance of `Helmet` with no headers set.
     pub fn new() -> Self {
-        Self::from(HelmetCore::new())
+        Self(HelmetCore::new())
     }
 
-    /// Add a header to the middleware.
+    /// Add a header.
     #[allow(clippy::should_implement_trait)]
-    pub fn add(mut self, header: impl Into<helmet_core::Header>) -> Self {
-        let header = header.into();
-        let name = HeaderName::try_from(header.0).expect("invalid header name");
-        let value = HeaderValue::from_str(&header.1).expect("invalid header value");
-        self.headers.append(name, value);
-        self
+    pub fn add(self, header: impl Into<helmet_core::Header>) -> Self {
+        Self(self.0.add(header))
+    }
+
+    /// Convert into [`HelmetMiddleware`].
+    ///
+    /// Poem's `EndpointExt::with()` takes `T: Middleware<E>`, but Rust's type
+    /// inference cannot resolve the target type of `try_into()` through the `?`
+    /// operator, so `.with(helmet.try_into()?)` does not compile. This method
+    /// lets you write `.with(helmet.into_middleware()?)` instead.
+    pub fn into_middleware(self) -> Result<HelmetMiddleware, HelmetError> {
+        self.try_into()
     }
 }
 
-impl From<HelmetCore> for Helmet {
-    fn from(core: HelmetCore) -> Self {
-        let headers = core
-            .headers
-            .iter()
-            .map(|header| {
-                (
-                    HeaderName::try_from(header.0).expect("invalid header name"),
-                    HeaderValue::from_str(&header.1).expect("invalid header value"),
-                )
-            })
-            .collect();
-        Self { headers }
+/// The Poem middleware created by converting a [`Helmet`] configuration.
+pub struct HelmetMiddleware {
+    headers: HeaderMap,
+}
+
+impl TryFrom<Helmet> for HelmetMiddleware {
+    type Error = HelmetError;
+
+    fn try_from(helmet: Helmet) -> std::result::Result<Self, Self::Error> {
+        let mut headers = HeaderMap::new();
+        for header in helmet.0.headers.iter() {
+            let name = HeaderName::try_from(header.0)
+                .map_err(|_| HelmetError::InvalidHeaderName(header.0.to_string()))?;
+            let value = HeaderValue::from_str(&header.1)
+                .map_err(|_| HelmetError::InvalidHeaderValue(header.1.clone()))?;
+            headers.insert(name, value);
+        }
+        Ok(Self { headers })
     }
 }
 
-impl<E: Endpoint> Middleware<E> for Helmet {
+impl<E: Endpoint> Middleware<E> for HelmetMiddleware {
     type Output = HelmetEndpoint<E>;
 
     fn transform(&self, ep: E) -> Self::Output {
@@ -152,7 +161,7 @@ impl<E: Endpoint> Middleware<E> for Helmet {
     }
 }
 
-/// The endpoint wrapper created by [`Helmet`] middleware.
+/// The endpoint wrapper created by [`HelmetMiddleware`].
 pub struct HelmetEndpoint<E> {
     ep: E,
     headers: HeaderMap,
@@ -163,8 +172,9 @@ impl<E: Endpoint> Endpoint for HelmetEndpoint<E> {
 
     async fn call(&self, req: Request) -> Result<Self::Output> {
         let mut resp = self.ep.call(req).await?.into_response();
-        resp.headers_mut()
-            .extend(self.headers.iter().map(|(k, v)| (k.clone(), v.clone())));
+        for (name, value) in self.headers.iter() {
+            resp.headers_mut().insert(name.clone(), value.clone());
+        }
         Ok(resp)
     }
 }
@@ -181,12 +191,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_helmet() {
-        let app = Route::new().at("/", index).with(
-            Helmet::new()
-                .add(helmet_core::XContentTypeOptions::nosniff())
-                .add(helmet_core::XFrameOptions::same_origin())
-                .add(helmet_core::XXSSProtection::on().mode_block()),
-        );
+        let mw: HelmetMiddleware = Helmet::new()
+            .add(helmet_core::XContentTypeOptions::nosniff())
+            .add(helmet_core::XFrameOptions::same_origin())
+            .add(helmet_core::XXSSProtection::on().mode_block())
+            .try_into()
+            .unwrap();
+
+        let app = Route::new().at("/", index).with(mw);
 
         let client = TestClient::new(app);
         let resp = client.get("/").send().await;
@@ -199,7 +211,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_helmet_default() {
-        let app = Route::new().at("/", index).with(Helmet::default());
+        let mw: HelmetMiddleware = Helmet::default().try_into().unwrap();
+        let app = Route::new().at("/", index).with(mw);
 
         let client = TestClient::new(app);
         let resp = client.get("/").send().await;

--- a/packages/rocket-helmet/Cargo.toml
+++ b/packages/rocket-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket-helmet"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for Rocket web framework"
@@ -16,7 +16,7 @@ categories = [
 ]
 
 [dependencies]
-helmet-core = { path = "../helmet-core", version = "0.3.0" }
+helmet-core = { path = "../helmet-core", version = "1.0.0" }
 rocket = "0.5"
 
 [dev-dependencies]

--- a/packages/salvo-helmet/Cargo.toml
+++ b/packages/salvo-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salvo-helmet"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for Salvo web framework"
@@ -16,7 +16,7 @@ categories = [
 ]
 
 [dependencies]
-helmet-core = { path = "../helmet-core", version = "0.3.0" }
+helmet-core = { path = "../helmet-core", version = "1.0.0" }
 salvo = "0.89"
 http = "1.4"
 

--- a/packages/salvo-helmet/src/lib.rs
+++ b/packages/salvo-helmet/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```no_run
 //! use salvo::prelude::*;
-//! use salvo_helmet::Helmet;
+//! use salvo_helmet::{Helmet, HelmetHandler};
 //!
 //! #[handler]
 //! async fn index() -> &'static str {
@@ -17,8 +17,8 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let router = Router::with_hoop(Helmet::default())
-//!         .get(index);
+//!     let handler: HelmetHandler = Helmet::default().try_into().unwrap();
+//!     let router = Router::with_hoop(handler).get(index);
 //!
 //!     let acceptor = TcpListener::new("0.0.0.0:3000").bind().await;
 //!     Server::new(acceptor).serve(router).await;
@@ -48,11 +48,11 @@
 //!
 //! By default if you construct a new instance of `Helmet` it will not set any headers.
 //!
-//! It is possible to configure `Helmet` to set only the headers you want, by using the `add` method to add headers.
+//! It is possible to configure `Helmet` to set only the headers you want, by using the `add` method.
 //!
 //! ```no_run
 //! use salvo::prelude::*;
-//! use salvo_helmet::{Helmet, ContentSecurityPolicy, CrossOriginOpenerPolicy};
+//! use salvo_helmet::{Helmet, HelmetHandler, ContentSecurityPolicy, CrossOriginOpenerPolicy};
 //!
 //! #[handler]
 //! async fn index() -> &'static str {
@@ -61,16 +61,17 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let router = Router::with_hoop(
-//!             Helmet::new()
-//!                 .add(
-//!                     ContentSecurityPolicy::new()
-//!                         .default_src(vec!["'self'"])
-//!                         .script_src(vec!["'self'", "https://cdn.example.com"]),
-//!                 )
-//!                 .add(CrossOriginOpenerPolicy::same_origin_allow_popups()),
+//!     let handler: HelmetHandler = Helmet::new()
+//!         .add(
+//!             ContentSecurityPolicy::new()
+//!                 .default_src(vec!["'self'"])
+//!                 .script_src(vec!["'self'", "https://cdn.example.com"]),
 //!         )
-//!         .get(index);
+//!         .add(CrossOriginOpenerPolicy::same_origin_allow_popups())
+//!         .try_into()
+//!         .unwrap();
+//!
+//!     let router = Router::with_hoop(handler).get(index);
 //!
 //!     let acceptor = TcpListener::new("0.0.0.0:3000").bind().await;
 //!     Server::new(acceptor).serve(router).await;
@@ -85,64 +86,61 @@ use helmet_core::Helmet as HelmetCore;
 // re-export helmet_core::*, except for the `Helmet` struct
 pub use helmet_core::*;
 
-/// Helmet handler for Salvo.
+/// Helmet header configuration wrapper.
 ///
 /// Use `Helmet::default()` for a sensible set of default security headers,
 /// or `Helmet::new()` to start with no headers and add only the ones you need.
 ///
-/// Apply as a hoop (middleware) on a router:
+/// Convert to [`HelmetHandler`] via `try_into()` to use as a Salvo hoop.
 ///
 /// ```rust
-/// use salvo::prelude::*;
-/// use salvo_helmet::Helmet;
+/// use salvo_helmet::{Helmet, HelmetHandler};
 ///
-/// let router = Router::with_hoop(Helmet::default());
+/// let handler: HelmetHandler = Helmet::default().try_into().unwrap();
 /// ```
-pub struct Helmet {
-    headers: HeaderMap,
-}
-
-impl Default for Helmet {
-    fn default() -> Self {
-        Self::from(HelmetCore::default())
-    }
-}
+#[derive(Default)]
+pub struct Helmet(HelmetCore);
 
 impl Helmet {
     /// Create a new instance of `Helmet` with no headers set.
     pub fn new() -> Self {
-        Self::from(HelmetCore::new())
+        Self(HelmetCore::new())
     }
 
-    /// Add a header to the middleware.
+    /// Add a header.
     #[allow(clippy::should_implement_trait)]
-    pub fn add(mut self, header: impl Into<helmet_core::Header>) -> Self {
-        let header = header.into();
-        let name = HeaderName::try_from(header.0).expect("invalid header name");
-        let value = HeaderValue::from_str(&header.1).expect("invalid header value");
-        self.headers.append(name, value);
-        self
+    pub fn add(self, header: impl Into<helmet_core::Header>) -> Self {
+        Self(self.0.add(header))
+    }
+
+    pub fn into_handler(self) -> Result<HelmetHandler, HelmetError> {
+        self.try_into()
     }
 }
 
-impl From<HelmetCore> for Helmet {
-    fn from(core: HelmetCore) -> Self {
-        let headers = core
-            .headers
-            .iter()
-            .map(|header| {
-                (
-                    HeaderName::try_from(header.0).expect("invalid header name"),
-                    HeaderValue::from_str(&header.1).expect("invalid header value"),
-                )
-            })
-            .collect();
-        Self { headers }
+/// The Salvo handler created by converting a [`Helmet`] configuration.
+pub struct HelmetHandler {
+    headers: HeaderMap,
+}
+
+impl TryFrom<Helmet> for HelmetHandler {
+    type Error = HelmetError;
+
+    fn try_from(helmet: Helmet) -> Result<Self, Self::Error> {
+        let mut headers = HeaderMap::new();
+        for header in helmet.0.headers.iter() {
+            let name = HeaderName::try_from(header.0)
+                .map_err(|_| HelmetError::InvalidHeaderName(header.0.to_string()))?;
+            let value = HeaderValue::from_str(&header.1)
+                .map_err(|_| HelmetError::InvalidHeaderValue(header.1.clone()))?;
+            headers.insert(name, value);
+        }
+        Ok(Self { headers })
     }
 }
 
 #[async_trait]
-impl Handler for Helmet {
+impl Handler for HelmetHandler {
     async fn handle(
         &self,
         req: &mut Request,
@@ -151,8 +149,9 @@ impl Handler for Helmet {
         ctrl: &mut FlowCtrl,
     ) {
         ctrl.call_next(req, depot, res).await;
-        res.headers_mut()
-            .extend(self.headers.iter().map(|(k, v)| (k.clone(), v.clone())));
+        for (name, value) in self.headers.iter() {
+            res.headers_mut().insert(name.clone(), value.clone());
+        }
     }
 }
 
@@ -173,10 +172,11 @@ mod tests {
             Helmet::new()
                 .add(helmet_core::XContentTypeOptions::nosniff())
                 .add(helmet_core::XFrameOptions::same_origin())
-                .add(helmet_core::XXSSProtection::on().mode_block()),
+                .add(helmet_core::XXSSProtection::on().mode_block())
+                .into_handler()
+                .unwrap(),
         )
         .get(index);
-
         let service = Service::new(router);
 
         let res = TestClient::get("http://localhost/").send(&service).await;
@@ -204,7 +204,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_helmet_default() {
-        let router = Router::with_hoop(Helmet::default()).get(index);
+        let handler: HelmetHandler = Helmet::default().try_into().unwrap();
+        let router = Router::with_hoop(handler).get(index);
         let service = Service::new(router);
 
         let res = TestClient::get("http://localhost/").send(&service).await;

--- a/packages/tide-helmet/Cargo.toml
+++ b/packages/tide-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tide-helmet"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for Tide web framework"
@@ -16,7 +16,7 @@ categories = [
 ]
 
 [dependencies]
-helmet-core = { path = "../helmet-core", version = "0.3.0" }
+helmet-core = { path = "../helmet-core", version = "1.0.0" }
 tide = "0.16"
 async-trait = "0.1"
 

--- a/packages/warp-helmet/Cargo.toml
+++ b/packages/warp-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warp-helmet"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for Warp web framework"
@@ -16,7 +16,7 @@ categories = [
 ]
 
 [dependencies]
-helmet-core = { path = "../helmet-core", version = "0.3.0" }
+helmet-core = { path = "../helmet-core", version = "1.0.0" }
 warp = "0.4"
 http = "1.4"
 

--- a/packages/warp-helmet/src/lib.rs
+++ b/packages/warp-helmet/src/lib.rs
@@ -8,11 +8,11 @@
 //!
 //! ```no_run
 //! use warp::Filter;
-//! use warp_helmet::Helmet;
+//! use warp_helmet::{Helmet, HelmetFilter};
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let helmet = Helmet::default();
+//!     let helmet: HelmetFilter = Helmet::default().try_into().unwrap();
 //!
 //!     let route = helmet.wrap(
 //!         warp::path::end().map(|| "Hello, world!")
@@ -45,21 +45,23 @@
 //!
 //! By default if you construct a new instance of `Helmet` it will not set any headers.
 //!
-//! It is possible to configure `Helmet` to set only the headers you want, by using the `add` method to add headers.
+//! It is possible to configure `Helmet` to set only the headers you want, by using the `add` method.
 //!
 //! ```no_run
 //! use warp::Filter;
-//! use warp_helmet::{Helmet, ContentSecurityPolicy, CrossOriginOpenerPolicy};
+//! use warp_helmet::{Helmet, HelmetFilter, ContentSecurityPolicy, CrossOriginOpenerPolicy};
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let helmet = Helmet::new()
+//!     let helmet: HelmetFilter = Helmet::new()
 //!         .add(
 //!             ContentSecurityPolicy::new()
 //!                 .default_src(vec!["'self'"])
 //!                 .script_src(vec!["'self'", "https://cdn.example.com"]),
 //!         )
-//!         .add(CrossOriginOpenerPolicy::same_origin_allow_popups());
+//!         .add(CrossOriginOpenerPolicy::same_origin_allow_popups())
+//!         .try_into()
+//!         .unwrap();
 //!
 //!     let route = helmet.wrap(
 //!         warp::path::end().map(|| "Hello, world!")
@@ -77,47 +79,45 @@ use helmet_core::Helmet as HelmetCore;
 // re-export helmet_core::*, except for the `Helmet` struct
 pub use helmet_core::*;
 
-/// Helmet middleware for Warp.
+/// Helmet header configuration wrapper.
 ///
 /// Use `Helmet::default()` for a sensible set of default security headers,
 /// or `Helmet::new()` to start with no headers and add only the ones you need.
 ///
-/// ```rust
-/// use warp::Filter;
-/// use warp_helmet::Helmet;
+/// Convert to [`HelmetFilter`] via `try_into()` to use with Warp.
 ///
-/// let helmet = Helmet::default();
-/// let route = helmet.wrap(
-///     warp::any().map(|| "Hello, world!")
-/// );
+/// ```rust
+/// use warp_helmet::{Helmet, HelmetFilter};
+///
+/// let filter: HelmetFilter = Helmet::default().try_into().unwrap();
 /// ```
-#[derive(Clone)]
-pub struct Helmet {
-    headers: HeaderMap,
-}
-
-impl Default for Helmet {
-    fn default() -> Self {
-        Self::from(HelmetCore::default())
-    }
-}
+#[derive(Default)]
+pub struct Helmet(HelmetCore);
 
 impl Helmet {
     /// Create a new instance of `Helmet` with no headers set.
     pub fn new() -> Self {
-        Self::from(HelmetCore::new())
+        Self(HelmetCore::new())
     }
 
-    /// Add a header to the middleware.
+    /// Add a header.
     #[allow(clippy::should_implement_trait)]
-    pub fn add(mut self, header: impl Into<helmet_core::Header>) -> Self {
-        let header = header.into();
-        let name = HeaderName::try_from(header.0).expect("invalid header name");
-        let value = HeaderValue::from_str(&header.1).expect("invalid header value");
-        self.headers.append(name, value);
-        self
+    pub fn add(self, header: impl Into<helmet_core::Header>) -> Self {
+        Self(self.0.add(header))
     }
 
+    pub fn into_filter(self) -> Result<HelmetFilter, HelmetError> {
+        self.try_into()
+    }
+}
+
+/// The Warp filter wrapper created by converting a [`Helmet`] configuration.
+#[derive(Clone)]
+pub struct HelmetFilter {
+    headers: HeaderMap,
+}
+
+impl HelmetFilter {
     /// Wrap a filter to add security headers to all its responses.
     pub fn wrap<F, R>(
         self,
@@ -131,26 +131,26 @@ impl Helmet {
         filter.map(move |reply: R| {
             let mut resp = reply.into_response();
             for (name, value) in headers.iter() {
-                resp.headers_mut().append(name, value.clone());
+                resp.headers_mut().insert(name, value.clone());
             }
             resp
         })
     }
 }
 
-impl From<HelmetCore> for Helmet {
-    fn from(core: HelmetCore) -> Self {
-        let headers = core
-            .headers
-            .iter()
-            .map(|header| {
-                (
-                    HeaderName::try_from(header.0).expect("invalid header name"),
-                    HeaderValue::from_str(&header.1).expect("invalid header value"),
-                )
-            })
-            .collect();
-        Self { headers }
+impl TryFrom<Helmet> for HelmetFilter {
+    type Error = HelmetError;
+
+    fn try_from(helmet: Helmet) -> Result<Self, Self::Error> {
+        let mut headers = HeaderMap::new();
+        for header in helmet.0.headers.iter() {
+            let name = HeaderName::try_from(header.0)
+                .map_err(|_| HelmetError::InvalidHeaderName(header.0.to_string()))?;
+            let value = HeaderValue::from_str(&header.1)
+                .map_err(|_| HelmetError::InvalidHeaderValue(header.1.clone()))?;
+            headers.insert(name, value);
+        }
+        Ok(Self { headers })
     }
 }
 
@@ -160,12 +160,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_helmet() {
-        let helmet = Helmet::new()
+        let route = Helmet::new()
             .add(helmet_core::XContentTypeOptions::nosniff())
             .add(helmet_core::XFrameOptions::same_origin())
-            .add(helmet_core::XXSSProtection::on().mode_block());
-
-        let route = helmet.wrap(warp::path::end().map(|| "Hello, world!"));
+            .add(helmet_core::XXSSProtection::on().mode_block())
+            .into_filter()
+            .unwrap()
+            .wrap(warp::path::end().map(|| "Hello, world!"));
 
         let res = warp::test::request().path("/").reply(&route).await;
 
@@ -192,7 +193,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_helmet_default() {
-        let route = Helmet::default().wrap(warp::path::end().map(|| "Hello, world!"));
+        let helmet: HelmetFilter = Helmet::default().try_into().unwrap();
+        let route = helmet.wrap(warp::path::end().map(|| "Hello, world!"));
 
         let res = warp::test::request().path("/").reply(&route).await;
 


### PR DESCRIPTION
## Summary

- **Fix CSP reporting model**: split `report_to` (endpoint name) and `report_uri` (URLs) which were incorrectly conflated into a single directive
- **Deprecate `XFrameOptions::AllowFrom`**: ignored by all modern browsers, gives false sense of security — migrate to `ContentSecurityPolicy::frame_ancestors()`
- **Standardise header insertion**: all adapters now use `insert` (overwrite) semantics, preventing duplicate security headers
- **Fallible construction at framework boundary**: `Helmet` is an infallible config wrapper; conversion to framework middleware via `TryFrom`/`.into_middleware()` surfaces invalid header errors at setup time, not per-request
- **Ergonomic convenience methods**: `into_middleware()`, `into_filter()`, `into_handler()` on each adapter's `Helmet` for natural chaining
- **Bump all crates to v1.0.0**
