### PR TITLE
fix: axum-helmet use axum only for tests

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -3,7 +3,24 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 jobs:
+  fmt:
+    name: Fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --check
   clippy:
     name: Clippy
     permissions: write-all
@@ -36,8 +53,10 @@ jobs:
   publish:
     name: Publish
     needs:
+      - fmt
       - test
       - clippy
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.DS_Store

--- a/packages/actix-web-helmet/README.md
+++ b/packages/actix-web-helmet/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-actix-web-helmet = "0.1"
+actix-web-helmet = "1.0.0"
 ```
 
 ## Example

--- a/packages/axum-helmet/Cargo.toml
+++ b/packages/axum-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-helmet"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware core for axum web framework"
@@ -18,14 +18,13 @@ categories = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.8"
 helmet-core = { path = "../helmet-core", version = "1.0.0" }
 tower = "0.5"
 tower-service = "0.3"
 http = "1.4"
 pin-project-lite = "0.2"
-tokio = "1.50"
 
 [dev-dependencies]
+axum = "0.8"
 axum-test = "19"
-tokio = { version = "1.50", features = ["rt-multi-thread"] }
+tokio = { version = "1.50", features = ["macros", "rt-multi-thread"] }

--- a/packages/axum-helmet/README.md
+++ b/packages/axum-helmet/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-axum-helmet = "0.1"
+axum-helmet = "1.0.1"
 ```
 
 ## Example

--- a/packages/helmet-core/README.md
+++ b/packages/helmet-core/README.md
@@ -32,7 +32,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-helmet-core = "0.1"
+helmet-core = "1.0.0"
 ```
 
 Implementing the middleware is different for each framework. See the README for your framework of choice to see how to use it.

--- a/packages/ntex-helmet/README.md
+++ b/packages/ntex-helmet/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ntex-helmet = "0.1"
+ntex-helmet = "1.0.0"
 ```
 
 ## Example


### PR DESCRIPTION
## Summary
- bump `axum-helmet` from `1.0.0` to `1.0.1`
- remove `axum` from normal dependencies and keep it only in `dev-dependencies`
- trim `tokio` dev features to the minimum needed for the current tests and doctests
- ignore `.DS_Store` in the repo root
- updated stale README snippets

## Verification
- `cargo check -p axum-helmet --lib`
- `cargo test -p axum-helmet`

## Notes
- this follows feedback in [tokio-rs/axum#3684](https://github.com/tokio-rs/axum/pull/3684), where a maintainer suggested removing the `axum` dependency if the crate implementation does not require it at library compile time
