### PR TITLE
docs: bring docs in line with v1.0.0 API changes

### DIFF
--- a/packages/actix-web-helmet/Cargo.toml
+++ b/packages/actix-web-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-helmet"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for actix-web"

--- a/packages/actix-web-helmet/README.md
+++ b/packages/actix-web-helmet/README.md
@@ -28,22 +28,25 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-actix-web-helmet = "1.0.0"
+actix-web-helmet = "1.0.1"
 ```
 
 ## Example
 
 ```rust
-use actix_web::{web, App, HttpResponse};
+use actix_web::{web, App, HttpResponse, HttpServer};
 use actix_web_helmet::Helmet;
 
 #[actix_web::main]
-async fn main() {
-    let app = App::new()
-        .wrap(Helmet::default())
-        .service(web::resource("/").to(|| HttpResponse::Ok()));
-
-    // ...
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new()
+            .wrap(Helmet::default().into_middleware().unwrap())
+            .service(web::resource("/").to(HttpResponse::Ok))
+    })
+    .bind("0.0.0.0:3000")?
+    .run()
+    .await
 }
 ```
 

--- a/packages/axum-helmet/Cargo.toml
+++ b/packages/axum-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-helmet"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware core for axum web framework"

--- a/packages/axum-helmet/README.md
+++ b/packages/axum-helmet/README.md
@@ -26,20 +26,26 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-axum-helmet = "1.0.1"
+axum-helmet = "1.0.2"
 ```
 
 ## Example
 
 ```rust
-use axum::{self, Router};
-use axum_helmet::Helmet;
+use axum::{routing::get, Router};
+use axum_helmet::{Helmet, HelmetLayer};
 
-let app = Router::new()
-    .route("/", axum::handler::get(|| async { "Hello, World!" }))
-    .layer(Helmet::default());
+#[tokio::main]
+async fn main() {
+    let layer: HelmetLayer = Helmet::default().try_into().unwrap();
 
-// ...
+    let app = Router::new()
+        .route("/", get(|| async { "Hello, World!" }))
+        .layer(layer);
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}
 ```
 
 ## License

--- a/packages/helmet-core/Cargo.toml
+++ b/packages/helmet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helmet-core"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware core for various web frameworks"

--- a/packages/helmet-core/README.md
+++ b/packages/helmet-core/README.md
@@ -4,10 +4,13 @@
 [![docs](https://docs.rs/helmet-core/badge.svg)](https://docs.rs/helmet-core)
 
 - `ntex-helmet` is a security middleware for the `ntex` web framework.
-- `actix-web-helmet` is a security middleware for the `actix-web` web framework. **_Coming Soon_**
-- `rocket-helmet` is a security middleware for the `rocket` web framework. **_Coming Soon_**
-- `warp-helmet` is a security middleware for the `warp` web framework. **_Coming Soon_**
+- `actix-web-helmet` is a security middleware for the `actix-web` web framework.
+- `rocket-helmet` is a security middleware for the `rocket` web framework.
+- `warp-helmet` is a security middleware for the `warp` web framework.
 - `axum-helmet` is a security middleware for the `axum` web framework.
+- `poem-helmet` is a security middleware for the `poem` web framework.
+- `salvo-helmet` is a security middleware for the `salvo` web framework.
+- `tide-helmet` is a security middleware for the `tide` web framework.
 
 It works by setting HTTP headers for you. These headers can help protect your app from some well-known web vulnerabilities:
 
@@ -32,27 +35,29 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-helmet-core = "1.0.0"
+helmet-core = "1.0.1"
 ```
 
 Implementing the middleware is different for each framework. See the README for your framework of choice to see how to use it.
 
 ## Example
 
-```rust
+If your framework already has a `*-helmet` crate, prefer that. Otherwise, you
+can wrap `helmet_core::Helmet` yourself — the `headers` field is a
+`Vec<(&'static str, String)>` that you copy onto each response.
+
+```rust,ignore
 use helmet_core::Helmet;
 
 let helmet = Helmet::default();
 
-struct MyCustomFrameworkMiddleware(Helmet);
+struct MyFrameworkMiddleware(Helmet);
 
-// Imagine this is a middleware for your favorite framework
-impl<S, B> Middleware<S, B> for MyCustomFrameworkMiddleware {
-    fn start(&self, req: &mut Request<S>) -> Result<Started> {
-        self.0.headers.iter().for_each(|(k, v)| {
-            req.headers_mut().insert(k, v.clone());
-        });
-        Ok(Started::Done)
+impl<S, B> Middleware<S, B> for MyFrameworkMiddleware {
+    fn on_response(&self, res: &mut Response<B>) {
+        for (name, value) in &self.0.headers {
+            res.headers_mut().insert(*name, value.clone());
+        }
     }
 }
 ```

--- a/packages/ntex-helmet/Cargo.toml
+++ b/packages/ntex-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntex-helmet"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for ntex-web"

--- a/packages/ntex-helmet/README.md
+++ b/packages/ntex-helmet/README.md
@@ -28,22 +28,26 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ntex-helmet = "1.0.0"
+ntex-helmet = "1.0.1"
 ```
 
 ## Example
 
 ```rust
-use ntex::web::{self, App, HttpResponse};
+use ntex::web::{self, App, HttpResponse, HttpServer};
 use ntex_helmet::Helmet;
 
 #[ntex::main]
-fn main() {
-    let app = App::new()
-        .wrap(Helmet::default())
-        .service(web::resource("/").to(|| HttpResponse::Ok()));
-
-    // ...
+async fn main() -> std::io::Result<()> {
+    let helmet = Helmet::default().into_middleware().unwrap();
+    HttpServer::new(move || {
+        App::new()
+            .middleware(helmet.clone())
+            .service(web::resource("/").to(|| async { HttpResponse::Ok() }))
+    })
+    .bind("0.0.0.0:3000")?
+    .run()
+    .await
 }
 ```
 

--- a/packages/poem-helmet/Cargo.toml
+++ b/packages/poem-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poem-helmet"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for Poem web framework"

--- a/packages/poem-helmet/README.md
+++ b/packages/poem-helmet/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-poem-helmet = "0.3"
+poem-helmet = "1.0"
 ```
 
 ## Example
@@ -44,7 +44,7 @@ fn index() -> &'static str {
 async fn main() -> Result<(), std::io::Error> {
     let app = Route::new()
         .at("/", get(index))
-        .with(Helmet::default());
+        .with(Helmet::default().into_middleware().unwrap());
 
     Server::new(TcpListener::bind("0.0.0.0:3000"))
         .run(app)

--- a/packages/salvo-helmet/Cargo.toml
+++ b/packages/salvo-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salvo-helmet"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for Salvo web framework"

--- a/packages/salvo-helmet/README.md
+++ b/packages/salvo-helmet/README.md
@@ -26,14 +26,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-salvo-helmet = "0.3"
+salvo-helmet = "1.0"
 ```
 
 ## Example
 
 ```rust
 use salvo::prelude::*;
-use salvo_helmet::Helmet;
+use salvo_helmet::{Helmet, HelmetHandler};
 
 #[handler]
 async fn index() -> &'static str {
@@ -42,8 +42,9 @@ async fn index() -> &'static str {
 
 #[tokio::main]
 async fn main() {
-    let router = Router::with_hoop(Helmet::default())
-        .get(index);
+    let helmet: HelmetHandler = Helmet::default().try_into().unwrap();
+
+    let router = Router::with_hoop(helmet).get(index);
 
     let acceptor = TcpListener::new("0.0.0.0:3000").bind().await;
     Server::new(acceptor).serve(router).await;

--- a/packages/warp-helmet/Cargo.toml
+++ b/packages/warp-helmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warp-helmet"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Daniel Kovacs <kovacsemod@gmail.com>"]
 description = "HTTP security headers middleware for Warp web framework"

--- a/packages/warp-helmet/README.md
+++ b/packages/warp-helmet/README.md
@@ -26,18 +26,18 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-warp-helmet = "0.3"
+warp-helmet = "1.0"
 ```
 
 ## Example
 
 ```rust
 use warp::Filter;
-use warp_helmet::Helmet;
+use warp_helmet::{Helmet, HelmetFilter};
 
 #[tokio::main]
 async fn main() {
-    let helmet = Helmet::default();
+    let helmet: HelmetFilter = Helmet::default().try_into().unwrap();
 
     let route = helmet.wrap(
         warp::path::end().map(|| "Hello, world!")


### PR DESCRIPTION
Closes #10 

## What changed

Updated docs to be in line with breaking API changes introduced in v1.0.0.

## Why

Docs lagged behind, causing confusion at integration time.